### PR TITLE
Feature/json key value cache

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -26,7 +26,7 @@ return array(
     'label' => 'Result visualisation',
     'description' => 'TAO Results extension',
     'license' => 'GPL-2.0',
-    'version' => '3.2.2',
+    'version' => '3.3.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     // taoItems is only needed for the item model property retrieval
     'requires' => array(

--- a/model/table/VariableDataProvider.php
+++ b/model/table/VariableDataProvider.php
@@ -102,8 +102,9 @@ class VariableDataProvider implements tao_models_classes_table_DataProvider
                     $varData = $var->variable;
                     if (common_cache_FileCache::singleton()->has('variableDataCache' . $var->uri . '_' . $varData->getIdentifier())) {
                         $varData = common_cache_FileCache::singleton()->get('variableDataCache' . $var->uri . '_' . $varData->getIdentifier());
+                        $varData = \taoResultServer_models_classes_Variable::fromArray($varData);
                     } else {
-                        common_cache_FileCache::singleton()->put($varData, 'variableDataCache' . $var->uri . '_' . $varData->getIdentifier());
+                        common_cache_FileCache::singleton()->put($varData->__toArray(), 'variableDataCache' . $var->uri . '_' . $varData->getIdentifier());
                     }
                     
                     if ($varData->getBaseType() === 'file') {

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -56,6 +56,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $$this->setVersion('2.6.1');
         }
 
-        $this->skip('2.6.1', '3.2.2');
+        $this->skip('2.6.1', '3.3.0');
     }
 }


### PR DESCRIPTION
**DEPENDS ON 
https://github.com/oat-sa/generis/pull/311
https://github.com/oat-sa/tao-core/pull/1212
https://github.com/oat-sa/extension-tao-outcome/pull/65**

Enable "array serialization" for Menu Model in TAO Outcome UI, in order to be "JSON Cacheable". See dependent PR https://github.com/oat-sa/generis/pull/311 for more information about the intent.