### PR TITLE
Feature/tao 4906 use async queue export

### DIFF
--- a/controller/ResultTable.php
+++ b/controller/ResultTable.php
@@ -120,7 +120,7 @@ class ResultTable extends \tao_actions_CommonModule
     /**
      * Create a task to export delivery results
      * A json message is returned with a feedback message
-     * 
+     *
      * @throws \common_exception_MethodNotAllowed
      * @throws \common_exception_MissingParameter
      */

--- a/controller/ResultTable.php
+++ b/controller/ResultTable.php
@@ -99,7 +99,7 @@ class ResultTable extends \tao_actions_CommonModule
         }
         $delivery = $this->getResource(tao_helpers_Uri::decode($this->getRequestParameter('uri')));
 
-        if ($this->getResultsService()->hasSynchronousExport()) {
+        if ($this->getResultsService()->isSynchronousExport()) {
             $file = $this->getResultsService()->exportDeliveryResults($delivery);
             header("Content-type: text/csv");
             header('Content-Disposition: attachment; fileName="' . $file->getBasename() .'"');

--- a/controller/ResultTable.php
+++ b/controller/ResultTable.php
@@ -97,21 +97,18 @@ class ResultTable extends \tao_actions_CommonModule
         if (!$this->hasRequestParameter('uri')) {
             throw new \common_exception_MissingParameter('uri', __FUNCTION__);
         }
-
         $delivery = $this->getResource(tao_helpers_Uri::decode($this->getRequestParameter('uri')));
-        $file = $this->getResultsService()->getCsvByDelivery($delivery);
-        \common_Logger::i($file->read());
-        \common_Logger::i($file->getPrefix());
-        \common_Logger::i($file->getSize());
 
-        header('Set-Cookie: fileDownload=true'); //used by jquery file download to find out the download has been triggered ...
-        setcookie("fileDownload","true", 0, "/");
-        header("Content-type: text/csv");
-        header('Content-Disposition: attachment; filename=Data.csv');
-        //header('Content-Disposition: attachment; fileName="' . $file->getBasename() .'"');
-        header("Content-Length: " . $file->getSize());
+        if ($this->getResultsService()->hasSynchronousExport()) {
+            $file = $this->getResultsService()->exportDeliveryResults($delivery);
+            header("Content-type: text/csv");
+            header('Content-Disposition: attachment; fileName="' . $file->getBasename() .'"');
+            header("Content-Length: " . $file->getSize());
+            echo $file->read();
+        } else {
+            throw new \common_exception_NotImplemented();
+        }
 
-        echo $file->read();
     }
 
     /**

--- a/controller/ResultTable.php
+++ b/controller/ResultTable.php
@@ -25,6 +25,7 @@ use \common_Exception;
 use \core_kernel_classes_Property;
 use \core_kernel_classes_Resource;
 use oat\generis\model\OntologyAwareTrait;
+use oat\taoOutcomeUi\model\export\ResultExportService;
 use \tao_models_classes_table_Column;
 use \tao_models_classes_table_PropertyColumn;
 use oat\taoOutcomeUi\model\ResultsService;
@@ -99,8 +100,8 @@ class ResultTable extends \tao_actions_CommonModule
         }
         $delivery = $this->getResource(tao_helpers_Uri::decode($this->getRequestParameter('uri')));
 
-        if ($this->getResultsService()->isSynchronousExport()) {
-            $file = $this->getResultsService()->exportDeliveryResults($delivery);
+        if ($this->getResultExportService()->isSynchronousExport()) {
+            $file = $this->getResultExportService()->exportDeliveryResults($delivery);
             header("Content-type: text/csv");
             header('Content-Disposition: attachment; fileName="' . $file->getBasename() .'"');
             header("Content-Length: " . $file->getSize());
@@ -108,7 +109,7 @@ class ResultTable extends \tao_actions_CommonModule
         } else {
             $this->setData('uri', tao_helpers_Uri::encode($delivery->getUri()));
             $this->setData('label', $delivery->getLabel());
-            $this->setData('context', ResultsService::DELIVERY_EXPORT_QUEUE_CONTEXT);
+            $this->setData('context', ResultExportService::DELIVERY_EXPORT_QUEUE_CONTEXT);
             $this->setData(
                 'create-task-callback-url',
                 _url('createCsvFileByDeliveryTask',  \Context::getInstance()->getModuleName(), \Context::getInstance()->getExtensionName())
@@ -133,7 +134,7 @@ class ResultTable extends \tao_actions_CommonModule
             throw new \common_exception_MissingParameter('uri', __FUNCTION__);
         }
         $delivery = $this->getResource(tao_helpers_Uri::decode($this->getRequestParameter('uri')));
-        $task = $this->getResultsService()->createExportTask($delivery);
+        $task = $this->getResultExportService()->createExportTask($delivery);
 
         $this->returnJson(array(
             'success' => true,
@@ -379,12 +380,13 @@ class ResultTable extends \tao_actions_CommonModule
     }
 
     /**
-     * Get the results service
+     * Get the results export service
      *
-     * @return ResultsService
+     * @return ResultExportService
      */
-    protected function getResultsService()
+    protected function getResultExportService()
     {
-        return ResultsService::singleton();
+        return $this->getServiceManager()->propagate(new ResultExportService());
     }
+
 }

--- a/controller/structures.xml
+++ b/controller/structures.xml
@@ -15,7 +15,7 @@
                             />
                 </trees>
                 <actions>
-                    <action id="results-csv-export" name="Export CSV" url="/taoOutcomeUi/ResultTable/getCsvFileByDelivery" binding="download_csv" group="tree" context="instance">
+                    <action id="results-csv-export" name="Export CSV" url="/taoOutcomeUi/ResultTable/getCsvFileByDelivery" group="tree" context="instance">
                         <icon id="icon-download"/>
                     </action>
                     <action id="results-index" name="Results" url="/taoOutcomeUi/Results/index" group="content"

--- a/manifest.php
+++ b/manifest.php
@@ -30,7 +30,7 @@ return array(
     'label' => 'Result visualisation',
     'description' => 'TAO Results extension',
     'license' => 'GPL-2.0',
-    'version' => '4.7.2',
+    'version' => '4.8.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     // taoItems is only needed for the item model property retrieval
     'requires' => array(

--- a/manifest.php
+++ b/manifest.php
@@ -30,7 +30,7 @@ return array(
     'label' => 'Result visualisation',
     'description' => 'TAO Results extension',
     'license' => 'GPL-2.0',
-    'version' => '4.8.0',
+    'version' => '4.9.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     // taoItems is only needed for the item model property retrieval
     'requires' => array(

--- a/model/ResultsService.php
+++ b/model/ResultsService.php
@@ -915,7 +915,7 @@ class ResultsService extends tao_models_classes_ClassService {
      */
     public function exportDeliveryResults(core_kernel_classes_Resource $delivery)
     {
-        if (!$this->hasSynchronousExport()) {
+        if (!$this->isSynchronousExport()) {
             throw new common_Exception('Unable to get an export file, taskqueue is not synchronous.');
         }
 
@@ -956,7 +956,7 @@ class ResultsService extends tao_models_classes_ClassService {
      *
      * @return bool
      */
-    public function hasSynchronousExport()
+    public function isSynchronousExport()
     {
         return $this->getTaskQueue() instanceof SyncQueue;
     }

--- a/model/ResultsService.php
+++ b/model/ResultsService.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -15,7 +14,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2013 Open Assessment Technologies S.A.
+ * Copyright (c) 2013-2017 Open Assessment Technologies S.A.
  *
  *
  * @access public
@@ -30,27 +29,25 @@ use oat\oatbox\filesystem\FileSystemService;
 use oat\oatbox\task\implementation\SyncQueue;
 use oat\oatbox\task\Queue;
 use oat\oatbox\task\Task;
-use oat\taoOutcomeUi\helper\ResponseVariableFormatter;
 use oat\taoOutcomeUi\model\table\GradeColumn;
 use oat\taoOutcomeUi\model\table\ResponseColumn;
 use \common_Exception;
 use \common_Logger;
-use \common_cache_FileCache;
 use \common_exception_Error;
 use \core_kernel_classes_Class;
 use \core_kernel_classes_DbWrapper;
 use \core_kernel_classes_Property;
 use \core_kernel_classes_Resource;
-use oat\taoOutcomeUi\scripts\ExportDeliveryResults;
 use oat\taoOutcomeUi\scripts\task\ExportDeliveryResultsTask;
 use oat\taoResultServer\models\classes\ResultManagement;
-use \tao_helpers_Date;
 use \tao_models_classes_ClassService;
 use oat\taoOutcomeUi\helper\Datatypes;
 use oat\taoDelivery\model\execution\DeliveryExecution;
 use oat\taoResultServer\models\classes\ResultServerService;
 
-class ResultsService extends tao_models_classes_ClassService {
+class ResultsService extends tao_models_classes_ClassService
+{
+    const DELIVERY_EXPORT_QUEUE_CONTEXT = 'taoOutcomeUi/results-export-by-delivery';
 
     /**
      *
@@ -932,9 +929,9 @@ class ResultsService extends tao_models_classes_ClassService {
 
         $taskSuccessReports = $task->getReport()->getSuccesses();
         $taskReport = reset($taskSuccessReports);
-        $taskData = $taskReport->getData();
-        if (isset($taskData[ExportDeliveryResultsTask::EXPORT_FILE_KEY])) {
-            return $this->getQueueStorage()->getFile($taskData[ExportDeliveryResultsTask::EXPORT_FILE_KEY]);
+        $taskFile = $this->getQueueStorage()->getFile($taskReport->getData());
+        if ($taskFile->exists()) {
+            return $taskFile;
         }
 
         throw new common_Exception('Export result task does not have an exported file');
@@ -946,9 +943,15 @@ class ResultsService extends tao_models_classes_ClassService {
      * @param core_kernel_classes_Resource $delivery
      * @return Task
      */
-    protected function createExportTask(core_kernel_classes_Resource $delivery)
+    public function createExportTask(core_kernel_classes_Resource $delivery)
     {
-        return $this->getTaskQueue()->createTask(ExportDeliveryResultsTask::class, [$delivery->getUri()]);
+        return $this->getTaskQueue()->createTask(
+            ExportDeliveryResultsTask::class,
+            [$delivery->getUri()],
+            false,
+            __('CSV results export for delivery "%s"', $delivery->getLabel()),
+            self::DELIVERY_EXPORT_QUEUE_CONTEXT
+        );
     }
 
     /**

--- a/model/export/ResultExportService.php
+++ b/model/export/ResultExportService.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2017 Open Assessment Technologies S.A.
+ *
+ */
+namespace oat\taoOutcomeUi\model\export;
+
+use oat\oatbox\filesystem\Directory;
+use oat\oatbox\filesystem\FileSystemService;
+use oat\oatbox\task\implementation\SyncQueue;
+use oat\oatbox\task\Queue;
+use oat\oatbox\task\Task;
+use oat\taoOutcomeUi\scripts\task\ExportDeliveryResultsTask;
+use \common_Exception;
+use \core_kernel_classes_Resource;
+use Zend\ServiceManager\ServiceLocatorAwareInterface;
+use Zend\ServiceManager\ServiceLocatorAwareTrait;
+
+class ResultExportService implements ServiceLocatorAwareInterface
+{
+    use ServiceLocatorAwareTrait;
+
+    const DELIVERY_EXPORT_QUEUE_CONTEXT = 'taoOutcomeUi/results-export-by-delivery';
+
+    /**
+     * Use the sync queue to create a task executed immediately
+     * The created task contains a report with export file
+     *
+     * @param core_kernel_classes_Resource $delivery
+     * @return \oat\oatbox\filesystem\File
+     * @throws common_Exception
+     */
+    public function exportDeliveryResults(core_kernel_classes_Resource $delivery)
+    {
+        if (!$this->isSynchronousExport()) {
+            throw new common_Exception('Unable to get an export file, taskqueue is not synchronous.');
+        }
+
+        if (!$delivery->exists()) {
+            throw new common_Exception('The delivery to export does not exist.');
+        }
+
+        /** @var Task $task */
+        $task = $this->createExportTask($delivery);
+        $taskErrorReports = $task->getReport()->getErrors();
+        if (!empty($taskErrorReports)) {
+            throw new common_Exception('Task export has failed.');
+        }
+
+        $taskSuccessReports = $task->getReport()->getSuccesses();
+        $taskReport = reset($taskSuccessReports);
+        $taskFile = $this->getQueueStorage()->getFile($taskReport->getData());
+        if ($taskFile->exists()) {
+            return $taskFile;
+        }
+
+        throw new common_Exception('Export result task does not have an exported file');
+    }
+
+    /**
+     * Create a task to export result by delivery
+     *
+     * @param core_kernel_classes_Resource $delivery
+     * @return Task
+     */
+    public function createExportTask(core_kernel_classes_Resource $delivery)
+    {
+        return $this->getTaskQueue()->createTask(
+            ExportDeliveryResultsTask::class,
+            [$delivery->getUri()],
+            false,
+            __('CSV results export for delivery "%s"', $delivery->getLabel()),
+            self::DELIVERY_EXPORT_QUEUE_CONTEXT
+        );
+    }
+
+    /**
+     * Check if taskqueue is the sync one
+     *
+     * @return bool
+     */
+    public function isSynchronousExport()
+    {
+        return $this->getTaskQueue() instanceof SyncQueue;
+    }
+
+    /**
+     * Get the Queue service to manage tasks
+     *
+     * @return Queue
+     */
+    protected function getTaskQueue()
+    {
+        return $this->getServiceLocator()->get(Queue::SERVICE_ID);
+    }
+
+    /**
+     * Get the directory of Queue storage
+     *
+     * @return Directory
+     */
+    public function getQueueStorage()
+    {
+        return $this->getServiceLocator()->get(FileSystemService::SERVICE_ID)->getDirectory(Queue::FILE_SYSTEM_ID);
+    }
+}

--- a/scripts/task/ExportDeliveryResultsTask.php
+++ b/scripts/task/ExportDeliveryResultsTask.php
@@ -40,8 +40,6 @@ class ExportDeliveryResultsTask implements Action, ServiceLocatorAwareInterface
     use ServiceLocatorAwareTrait;
     use OntologyAwareTrait;
 
-    const EXPORT_FILE_KEY = 'exportedFile';
-
     /**
      * The delivery to extract results
      *
@@ -63,19 +61,14 @@ class ExportDeliveryResultsTask implements Action, ServiceLocatorAwareInterface
      */
     protected $tmpFile;
 
-    public function __construct()
-    {
-        //Load extension to define necessary constants.
-        // \common_ext_ExtensionsManager::singleton()->getExtensionById('taoOutcomeUi');
-        //\common_ext_ExtensionsManager::singleton()->getExtensionById('taoDeliveryRdf');
-    }
-
     /**
      * @param $params
      * @return Report
      */
     public function __invoke($params)
     {
+        $this->loadExtensions();
+
         try {
             $this->parseParams($params);
         } catch (ResolutionException $e) {
@@ -91,10 +84,8 @@ class ExportDeliveryResultsTask implements Action, ServiceLocatorAwareInterface
 
         return new Report(
             Report::TYPE_SUCCESS,
-            'Results successfully exported',
-            [
-                self::EXPORT_FILE_KEY => $file->getPrefix()
-            ]
+            __('Results successfully exported for delivery "%s"', $this->delivery->getLabel()),
+            $file->getPrefix()
         );
     }
 
@@ -260,5 +251,13 @@ class ExportDeliveryResultsTask implements Action, ServiceLocatorAwareInterface
     protected function getResultsService()
     {
         return ResultsService::singleton();
+    }
+
+    /**
+     * Load the required TAO extensions (for constants)
+     */
+    protected function loadExtensions()
+    {
+        $this->getServiceLocator()->get(\common_ext_ExtensionsManager::SERVICE_ID)->getExtensionById('taoOutcomeUi');
     }
 }

--- a/scripts/task/ExportDeliveryResultsTask.php
+++ b/scripts/task/ExportDeliveryResultsTask.php
@@ -24,6 +24,7 @@ use common_report_Report as Report;
 use oat\generis\model\OntologyAwareTrait;
 use oat\oatbox\action\Action;
 use oat\oatbox\filesystem\Directory;
+use oat\taoOutcomeUi\model\export\ResultExportService;
 use oat\taoOutcomeUi\model\table\VariableColumn;
 use oat\taoOutcomeUi\model\table\VariableDataProvider;
 use Zend\ServiceManager\ServiceLocatorAwareTrait;
@@ -202,7 +203,7 @@ class ExportDeliveryResultsTask implements Action, ServiceLocatorAwareInterface
     protected function createTaskFile()
     {
         /** @var Directory $queueStorage */
-        $queueStorage = $this->getResultsService()->getQueueStorage();
+        $queueStorage = $this->getResultExportService()->getQueueStorage();
         $file = $queueStorage->getFile(
             'delivery_results_export_' . \tao_helpers_Uri::getUniqueId($this->delivery->getUri()) . '_' . (new \DateTime())->format('Y-m-d_H-i') . '.csv'
         );
@@ -251,6 +252,16 @@ class ExportDeliveryResultsTask implements Action, ServiceLocatorAwareInterface
     protected function getResultsService()
     {
         return ResultsService::singleton();
+    }
+
+    /**
+     * Get the results export service
+     *
+     * @return ResultExportService
+     */
+    protected function getResultExportService()
+    {
+        return (new ResultExportService())->setServiceLocator($this->getServiceLocator());
     }
 
     /**

--- a/scripts/task/ExportDeliveryResultsTask.php
+++ b/scripts/task/ExportDeliveryResultsTask.php
@@ -1,0 +1,267 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2017 (original work) Open Assessment Technologies SA;
+ *
+ */
+
+namespace oat\taoOutcomeUi\scripts\task;
+
+use common_report_Report as Report;
+use oat\generis\model\OntologyAwareTrait;
+use oat\oatbox\action\Action;
+use oat\oatbox\filesystem\Directory;
+use oat\oatbox\filesystem\File;
+use oat\taoOutcomeUi\model\table\VariableColumn;
+use oat\taoOutcomeUi\model\table\VariableDataProvider;
+use Zend\ServiceManager\ServiceLocatorAwareTrait;
+use Zend\ServiceManager\ServiceLocatorAwareInterface;
+use oat\oatbox\action\ResolutionException;
+use oat\taoOutcomeUi\model\ResultsService;
+
+/**
+ * Class ExportDeliveryResultsTask
+ * @package oat\taoOutcomeUi\scripts
+ */
+class ExportDeliveryResultsTask implements Action, ServiceLocatorAwareInterface
+{
+    use ServiceLocatorAwareTrait;
+    use OntologyAwareTrait;
+
+    const EXPORT_FILE_KEY = 'exportFile';
+
+    /**
+     * The file to export results
+     *
+     * @var File
+     */
+    protected $file;
+
+    /**
+     * The PHP resource of export file
+     *
+     * @var resource
+     */
+    protected $resource;
+    /**
+     * The delivery to extract results
+     *
+     * @var \core_kernel_classes_Resource
+     */
+    protected $delivery;
+
+    public function __construct()
+    {
+        //Load extension to define necessary constants.
+        // \common_ext_ExtensionsManager::singleton()->getExtensionById('taoOutcomeUi');
+        \common_ext_ExtensionsManager::singleton()->getExtensionById('taoDeliveryRdf');
+    }
+
+    /**
+     * @param $params
+     * @return Report
+     */
+    public function __invoke($params)
+    {
+        try {
+            $this->parseParams($params);
+        } catch (ResolutionException $e) {
+            return new Report(Report::TYPE_ERROR, $e->getMessage());
+        }
+
+        try {
+            $this->exportData();
+            fclose($this->resource);
+        } catch (\common_Exception $e) {
+            return new Report(Report::TYPE_ERROR, $e->getMessage());
+        }
+
+        return new Report(
+            Report::TYPE_SUCCESS,
+            'Results successfully exported',
+            [
+                self::EXPORT_FILE_KEY => $this->file->getPrefix()
+            ]
+        );
+    }
+
+    /**
+     * Parse the provided parameters array to extract delivery uri.
+     *
+     * @param $params
+     * @throws ResolutionException If delivery uri is not provided and does not exist
+     */
+    protected function parseParams($params)
+    {
+        if (empty($params)) {
+            throw new ResolutionException(__('Parameters were not given. Expected Syntax: ExportDeliveryResults <deliveryId>'));
+        }
+
+        if (!isset($params[0])) {
+            throw new ResolutionException('Delivery uri was not specified');
+        }
+
+        $this->delivery = $this->getResource($params[0]);
+        if (!$this->delivery->exists()) {
+            throw new ResolutionException('Provided delivery does not exist.');
+        }
+    }
+
+    /**
+     * Fetch the delivery results data from result service.
+     * Format it and sort it by columns.
+     * Write the output to the export file
+     *
+     * @throws \common_Exception
+     * @throws \common_exception_Error
+     * @throws \core_kernel_persistence_Exception
+     */
+    protected function exportData()
+    {
+        $resultsService = $this->getResultsService();
+        $filter = 'lastSubmitted';
+
+        $columns = [];
+
+        $testTakerColumn[] = (new \tao_models_classes_table_PropertyColumn($this->getProperty(PROPERTY_RESULT_OF_SUBJECT)))->toArray();
+        $cols = array_merge(
+            $testTakerColumn,
+            $resultsService->getVariableColumns($this->delivery, \taoResultServer_models_classes_OutcomeVariable::class, $filter),
+            $resultsService->getVariableColumns($this->delivery, \taoResultServer_models_classes_ResponseVariable::class, $filter)
+        );
+
+        $dataProvider = new VariableDataProvider();
+        foreach ($cols as $col) {
+            $column = \tao_models_classes_table_Column::buildColumnFromArray($col);
+            if (!is_null($column)) {
+                if ($column instanceof VariableColumn) {
+                    $column->setDataProvider($dataProvider);
+                }
+                $columns[] = $column;
+            }
+        }
+        $columns[0]->label = __("Test taker");
+        $rows = $resultsService->getResultsByDelivery($this->delivery, $columns, $filter);
+        $columnNames = array_reduce($columns, function ($carry, $item) {
+            $carry[] = $item->label;
+            return $carry;
+        });
+
+
+        if (!empty($rows)) {
+            foreach ($rows as $row) {
+                $rowResult = [];
+                foreach ($row['cell'] as $rowKey => $rowVal) {
+                    $rowResult[$columnNames[$rowKey]] = $rowVal[0];
+                }
+                $this->exportToCsv($rowResult);
+            }
+        } else {
+            $this->exportToCsv([array_fill_keys($columnNames, '')]);
+        }
+    }
+
+    /**
+     * Write the given data array to export file
+     *
+     * @param $data
+     * @throws \common_Exception
+     */
+    protected function exportToCsv($data)
+    {
+        $resource = $this->getFileResource(array_keys($data));
+        fputcsv($resource, $data, $this->getCsvControl('delimiter'), $this->getCsvControl('enclosure'));
+    }
+
+    /**
+     * Get the file resource to write the export.
+     * If file is not instantiated, delete if exists and write headers
+     *
+     * @param array $headers
+     * @return File
+     * @throws \common_Exception
+     */
+    protected function getFile(array $headers)
+    {
+        if (!$this->file) {
+            /** @var Directory $queueStorage */
+            $queueStorage = $this->getResultsService()->getQueueStorage();
+            $this->file = $queueStorage->getFile(
+                'delivery_results_export_' . \tao_helpers_Uri::getUniqueId($this->delivery->getUri()) . '_' . (new \DateTime())->format('Y-m-d_H-i') . '.csv'
+            );
+
+            $buffer = fopen('php://temp', 'w');
+            fputcsv($buffer, $headers, $this->getCsvControl('delimiter'), $this->getCsvControl('enclosure'));
+            rewind($buffer);
+            $this->file->put($buffer);
+            fclose($buffer);
+        }
+
+        return $this->file;
+    }
+
+    /**
+     * Get the PHP resource of the export file
+     *
+     * @param array $headers
+     * @return false|resource
+     * @throws \common_Exception
+     */
+    protected function getFileResource(array $headers)
+    {
+        if (!$this->resource) {
+            $this->resource = $this->getFile($headers)->readStream();
+        }
+        return $this->resource;
+    }
+
+    /**
+     * Get the specified CSV control (delimiter or enclosure)
+     *
+     * @param $name
+     * @return mixed
+     * @throws \common_Exception
+     */
+    protected function getCsvControl($name)
+    {
+        $controls = [
+            'delimiter' => ',',
+            'enclosure' => '"',
+        ];
+
+        switch ($name) {
+            case 'delimiter':
+                return $controls['delimiter'];
+                break;
+            case 'enclosure':
+                return $controls['enclosure'];
+                break;
+            default:
+                throw new \common_Exception('Csv controls are delimiter or enclosure.');
+                break;
+        }
+    }
+
+    /**
+     * Get the results service
+     *
+     * @return ResultsService
+     */
+    protected function getResultsService()
+    {
+        return ResultsService::singleton();
+    }
+}

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -80,6 +80,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('4.6.1');
         }
 
-        $this->skip('4.6.1', '4.7.2');
+        $this->skip('4.6.1', '4.8.0');
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -80,6 +80,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('4.6.1');
         }
 
-        $this->skip('4.6.1', '4.8.0');
+        $this->skip('4.6.1', '4.9.0');
     }
 }

--- a/views/templates/export-taskqueue.tpl
+++ b/views/templates/export-taskqueue.tpl
@@ -1,0 +1,56 @@
+<div class="data-container-wrapper col-12">
+    <div class="grid-row">
+        <a href="#" id="export-delivery-results" class="btn-info">
+            <span class="icon-export"></span>
+            <?=__('Results export for delivery "%s"', get_data('label'));?>
+        </a>
+    </div>
+</div>
+<div class="data-container-wrapper col-12">
+    <div id="task-list"></div>
+</div>
+
+<script>
+    require([
+            'jquery',
+            'i18n',
+            'helpers',
+            'ui/feedback',
+            'ui/taskQueue/table'
+        ],
+        function($, __, helpers, feedback, taskQueueTableFactory) {
+
+            var $queueArea = $('#task-list');
+            var taskQueueTable = taskQueueTableFactory({
+                rows : 10,
+                context : '<?= get_data("context"); ?>',
+                dataUrl : helpers._url('getTasks', 'TaskQueueData', 'tao'),
+                statusUrl : helpers._url('getStatus', 'TaskQueueData', 'tao'),
+                removeUrl : helpers._url('archiveTask', 'TaskQueueData', 'tao'),
+                downloadUrl : helpers._url('downloadTask', 'TaskQueueData', 'tao')
+            })
+            .init()
+            .render($queueArea);
+
+            $('#export-delivery-results').off('click').on('click', function(e) {
+                e.preventDefault();
+                e.stopImmediatePropagation();
+                var toSend = {
+                    'uri': '<?= get_data("uri"); ?>'
+                };
+                $.ajax({
+                    url: '<?= get_data("create-task-callback-url"); ?>',
+                    type: "POST",
+                    data: toSend,
+                    dataType: 'json',
+                    success: function(response) {
+                        if (response.success) {
+                            feedback().success(response.message);
+                        } else {
+                            feedback().error(__('Something went wrong during task creation.'));
+                        }
+                    }
+                });
+            });
+        });
+</script>


### PR DESCRIPTION
Requires https://github.com/oat-sa/extension-tao-outcomeui/pull/123
In case of async queue, the export task will not return a file immediately. 
To handle the result tasks, the exportCsv button will show a taskqueue table with possibility to create an export task.

Instructions to enable queue : https://github.com/oat-sa/lib-oatbox-taskqueue