### PR TITLE
Fix/tao 5239 brs integration

### DIFF
--- a/controller/structures.xml
+++ b/controller/structures.xml
@@ -12,7 +12,7 @@
                           dataUrl="/taoOutcomeUi/Results/getOntologyData"
                           selectClass="results-class-index"
                           selectInstance="results-index"
-                          delete="results-delete"
+                          type="jstree"
                     />
                 </trees>
                 <actions>
@@ -23,12 +23,6 @@
                     </action>
                     <action id="results-index" name="Results" url="/taoOutcomeUi/Results/index" group="content" context="instance">
                         <icon id="icon-result-small"/>
-                    </action>
-                    <action id="results-view" name="View result" url="/taoOutcomeUi/Results/viewResult" group="content" context="tree">
-                        <icon id="icon-edit"/>
-                    </action>
-                    <action id="results-delete" name="Delete" binding="removeNode" url="/taoOutcomeUi/Results/delete" context="tree" group="tree">
-                        <icon id="icon-bin"/>
                     </action>
                     <action id="results-export" name="Export Table" url="/taoOutcomeUi/ResultTable/index" group="content"  context="instance">
                         <icon id="icon-table"/>

--- a/manifest.php
+++ b/manifest.php
@@ -31,7 +31,7 @@ return [
     'label'          => 'Result visualisation',
     'description'    => 'TAO Results extension',
     'license'        => 'GPL-2.0',
-    'version'        => '5.0.1',
+    'version'        => '5.0.2',
     'author'         => 'Open Assessment Technologies, CRP Henri Tudor',
     // taoItems is only needed for the item model property retrieval
     'requires'       => [

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -96,6 +96,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('5.0.0');
         }
 
-        $this->skip('5.0.0', '5.0.1');
+        $this->skip('5.0.0', '5.0.2');
     }
 }


### PR DESCRIPTION
Force to use the jstree provider for now since `rootNode` doesn't seem to be compatible with this kind the result API. 
Also removed unused actions