### PR TITLE
Fix/tao 7175 fix export results

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -37,7 +37,7 @@ return [
     'label'          => 'Result visualisation',
     'description'    => 'TAO Results extension',
     'license'        => 'GPL-2.0',
-    'version'        => '7.4.2',
+    'version'        => '7.4.3',
     'author'         => 'Open Assessment Technologies, CRP Henri Tudor',
     // taoItems is only needed for the item model property retrieval
     'requires'       => [

--- a/model/ResultsService.php
+++ b/model/ResultsService.php
@@ -585,7 +585,7 @@ class ResultsService extends tao_models_classes_ClassService implements ServiceL
             }
 
             $variableDescription = [
-                'uri' => $variablesByItem[$firstEpoch]['uri'],
+                'uri' => $itemVariable->uri,
                 'var' => $variable,
             ];
 

--- a/model/export/SingleDeliveryResultsExporter.php
+++ b/model/export/SingleDeliveryResultsExporter.php
@@ -128,8 +128,19 @@ class SingleDeliveryResultsExporter implements ResultsExporterInterface
      */
     public function getColumnsToExport()
     {
-        // if we have columns set from outside, let's use that otherwise we are querying for all type of columns
-        $columns = $this->columnsToExport ?: $this->columnsProvider->getAll();
+        if (!empty($this->columnsToExport)) {
+            $columns = $this->columnsToExport;
+        } else {
+            $variables = array_merge($this->columnsProvider->getGradeColumns(),$this->columnsProvider->getResponseColumns());
+            usort($variables, function ($a, $b) {
+                return strcmp($a["label"], $b["label"]);
+            });
+            $columns = array_merge(
+                $this->columnsProvider->getTestTakerColumns(),
+                $this->columnsProvider->getDeliveryColumns(),
+                $variables
+            );
+        }
 
         if (empty($this->builtColumns)) {
             // build column objects
@@ -331,7 +342,7 @@ class SingleDeliveryResultsExporter implements ResultsExporterInterface
                 $columns[] = $column;
             }
         }
-
+        
         return $columns;
     }
 }

--- a/model/table/VariableDataProvider.php
+++ b/model/table/VariableDataProvider.php
@@ -51,7 +51,7 @@ class VariableDataProvider implements tao_models_classes_table_DataProvider
      * @var VariableDataProvider
      */
     public static $singleton = null;
-    
+
     /**
      * Short description of method prepare
      *
@@ -71,7 +71,7 @@ class VariableDataProvider implements tao_models_classes_table_DataProvider
          */
         foreach ($resources as $result) {
             $itemresults = $resultsService->getVariables($result, false);
-            
+
             foreach ($itemresults as $itemResultUri => $vars) {
                 // cache the item information pertaining to a given itemResult (stable over time)
                 if (common_cache_FileCache::singleton()->has('itemResultItemCache' . $itemResultUri)) {
@@ -101,12 +101,13 @@ class VariableDataProvider implements tao_models_classes_table_DataProvider
                      * @var \taoResultServer_models_classes_Variable $varData
                      */
                     $varData = $var->variable;
-                    if (common_cache_FileCache::singleton()->has('variableDataCache' . $var->uri . '_' . $varData->getIdentifier())) {
-                        $varData = common_cache_FileCache::singleton()->get('variableDataCache' . $var->uri . '_' . $varData->getIdentifier());
+                    $cacheKey =  'variableDataCache' . $var->uri . '_' . $varData->getIdentifier() . '_' . tao_helpers_Date::getTimeStamp($varData->getEpoch());
+                    if (common_cache_FileCache::singleton()->has($cacheKey)) {
+                        $varData = common_cache_FileCache::singleton()->get($cacheKey);
                     } else {
-                        common_cache_FileCache::singleton()->put($varData, 'variableDataCache' . $var->uri . '_' . $varData->getIdentifier());
+                        common_cache_FileCache::singleton()->put($varData, $cacheKey);
                     }
-                    
+
                     if ($varData->getBaseType() === 'file') {
                         $decodedFile = Datatypes::decodeFile($varData->getValue());
                         $varData->setValue($decodedFile['name']);
@@ -114,7 +115,7 @@ class VariableDataProvider implements tao_models_classes_table_DataProvider
                     $variableIdentifier = (string) $varData->getIdentifier();
                     foreach ($columns as $column) {
                         if ($variableIdentifier == $column->getIdentifier() and $contextIdentifier == $column->getContextIdentifier()) {
-                            
+
                             $epoch = $varData->getEpoch();
                             $readableTime = "";
                             if ($epoch != "") {
@@ -147,19 +148,19 @@ class VariableDataProvider implements tao_models_classes_table_DataProvider
     public function getValue(core_kernel_classes_Resource $resource, tao_models_classes_table_Column $column)
     {
         $returnValue = array();
-        
+
         if (! $column instanceof VariableColumn) {
             throw new \common_exception_InconsistentData('Unexpected colum type ' . get_class($column) . ' for ' . __CLASS__);
         }
-        
+
         $vcUri = $column->getVariableType();
-        
+
         if (isset($this->cache[$vcUri][$resource->getUri()][$column->getContextIdentifier() . $column->getIdentifier()])) {
             $returnValue = $this->cache[$vcUri][$resource->getUri()][$column->getContextIdentifier() . $column->getIdentifier()];
         } else {
             common_Logger::d('no data for resource: ' . $resource->getUri() . ' column: ' . $column->getIdentifier());
         }
-        
+
         return $returnValue;
     }
 

--- a/model/table/VariableDataProvider.php
+++ b/model/table/VariableDataProvider.php
@@ -101,13 +101,7 @@ class VariableDataProvider implements tao_models_classes_table_DataProvider
                      * @var \taoResultServer_models_classes_Variable $varData
                      */
                     $varData = $var->variable;
-                    $cacheKey =  'variableDataCache' . $var->uri . '_' . $varData->getIdentifier() . '_' . tao_helpers_Date::getTimeStamp($varData->getEpoch());
-                    if (common_cache_FileCache::singleton()->has($cacheKey)) {
-                        $varData = common_cache_FileCache::singleton()->get($cacheKey);
-                    } else {
-                        common_cache_FileCache::singleton()->put($varData, $cacheKey);
-                    }
-
+                    
                     if ($varData->getBaseType() === 'file') {
                         $decodedFile = Datatypes::decodeFile($varData->getValue());
                         $varData->setValue($decodedFile['name']);

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -170,7 +170,7 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('5.13.0');
         }
 
-        $this->skip('5.13.0', '7.4.2');
+        $this->skip('5.13.0', '7.4.3');
 
     }
 }


### PR DESCRIPTION
This PR included fixes for:
- At CSV export & exportable table, only first attempt value is displayed (need to be the last)
- Columns for response & grade variables are ordered to keep consistency between

Need to be tested with Dynamo & Rds
