### PR TITLE
TAO-6785 - htmlize getdata

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -37,7 +37,7 @@ return [
     'label'          => 'Result visualisation',
     'description'    => 'TAO Results extension',
     'license'        => 'GPL-2.0',
-    'version'        => '7.4.3',
+    'version'        => '7.4.4',
     'author'         => 'Open Assessment Technologies, CRP Henri Tudor',
     // taoItems is only needed for the item model property retrieval
     'requires'       => [

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -170,7 +170,7 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('5.13.0');
         }
 
-        $this->skip('5.13.0', '7.4.3');
+        $this->skip('5.13.0', '7.4.4');
 
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -171,7 +171,7 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('5.13.0');
         }
 
-        $this->skip('5.13.0', '7.4.4');
+        $this->skip('5.13.0', '7.4.3');
 
         if ($this->isVersion('7.4.3')) {
             /** @var EventManager $eventManager */

--- a/views/templates/resultList.tpl
+++ b/views/templates/resultList.tpl
@@ -5,7 +5,7 @@ use oat\tao\helpers\Template;
 
 <div class="results-headings flex-container-full">
     <header>
-        <h2><?=get_data("title")?></h2>
+        <h2><?=_dh(get_data("title"))?></h2>
     </header>
 </div>
 


### PR DESCRIPTION
JIRA: https://oat-sa.atlassian.net/browse/TAO-6785 (see the comment section)

Steps to reproduce:
1. Log in as admin 
2. Create a delivery (guest access is enough)
3. Set label of the delivery: <script>alert('label')</script>
4. Go to the Results page
5. Alert pops up
6. Every time when you click on the delivery the alert will pop up

Root cause:
taoOutcomeUi/views/templates/resultList.tpl line 8 -> <?=get_data("title")?>
this way we don't escape the data

Suggestion for fixing:
At this point we can escape in php: <?=_dh(get_data("title"))?>