### PR TITLE
Prevent warning in PHP 7.3

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -37,7 +37,7 @@ return [
     'label'          => 'Result visualisation',
     'description'    => 'TAO Results extension',
     'license'        => 'GPL-2.0',
-    'version'        => '7.5.3',
+    'version'        => '7.5.4',
     'author'         => 'Open Assessment Technologies, CRP Henri Tudor',
     // taoItems is only needed for the item model property retrieval
     'requires'       => [

--- a/scripts/task/ExportDeliveryResults.php
+++ b/scripts/task/ExportDeliveryResults.php
@@ -174,7 +174,7 @@ class ExportDeliveryResults implements Action, ServiceLocatorAwareInterface, Wor
 
                         if (in_array(self::COLUMNS_CLI_VALUE_ALL, $columns)) {
                             // do nothing because SingleDeliveryResultsExporter will use all columns by default if no columns specified
-                            continue;
+                            break;
                         }
 
                         foreach ($columns as $column) {

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -182,6 +182,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('7.5.0');
         }
 
-        $this->skip('7.5.0', '7.5.3');
+        $this->skip('7.5.0', '7.5.4');
     }
 }


### PR DESCRIPTION
Targeting a 'switch' control structure with a 'continue' statement is strongly discouraged and will throw a warning as of PHP 7.3.
I've tested with this command: `sudo -u www-data php index.php 'oat\taoOutcomeUi\scripts\task\ExportDeliveryResults' <deliveryOrClassId> --columns=all`
This PR is to avoid this warning.