### PR TITLE
Version Bump to 7.7.0 for release

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -37,7 +37,7 @@ return [
     'label'          => 'Result visualisation',
     'description'    => 'TAO Results extension',
     'license'        => 'GPL-2.0',
-    'version'        => '7.6.0',
+    'version'        => '7.7.0',
     'author'         => 'Open Assessment Technologies, CRP Henri Tudor',
     // taoItems is only needed for the item model property retrieval
     'requires'       => [

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -182,6 +182,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('7.5.0');
         }
 
-        $this->skip('7.5.0', '7.6.0');
+        $this->skip('7.5.0', '7.7.0');
     }
 }


### PR DESCRIPTION
Seems like https://github.com/oat-sa/extension-tao-outcomeui/pull/254/files was merged in the last sprint but with the same version as the last release.