### PR TITLE
Feature/tao 7265 date range picker replacement

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -37,7 +37,7 @@ return [
     'label'          => 'Result visualisation',
     'description'    => 'TAO Results extension',
     'license'        => 'GPL-2.0',
-    'version'        => '7.7.0',
+    'version'        => '7.8.0',
     'author'         => 'Open Assessment Technologies, CRP Henri Tudor',
     // taoItems is only needed for the item model property retrieval
     'requires'       => [
@@ -45,7 +45,7 @@ return [
         'taoResultServer' => '>=7.0.0',
         'taoItems'        => '>=6.0.0',
         'taoDeliveryRdf'  => '>=6.0.0',
-        'tao'             => '>=30.0.0'
+        'tao'             => '>=32.0.0'
     ],
     'install'        => [
         'php' => [

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -182,6 +182,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('7.5.0');
         }
 
-        $this->skip('7.5.0', '7.7.0');
+        $this->skip('7.5.0', '7.8.0');
     }
 }

--- a/views/js/controller/resultTable.js
+++ b/views/js/controller/resultTable.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2014-2017 (original work) Open Assessment Technologies SA;
+ * Copyright (c) 2014-2019 (original work) Open Assessment Technologies SA;
  */
 
 /**

--- a/views/js/controller/resultTable.js
+++ b/views/js/controller/resultTable.js
@@ -28,7 +28,7 @@ define([
     'ui/feedback',
     'core/taskQueue/taskQueue',
     'ui/taskQueueButton/standardButton',
-    'ui/dateRange',
+    'ui/dateRange/dateRange',
     'ui/datatable'
 ], function($, _, __, module, urlUtil, feedback, taskQueue, standardTaskButtonFactory, dateRangeFactory) {
     'use strict';
@@ -41,7 +41,7 @@ define([
         /**
          * Controller entry point
          */
-        start : function(){
+        start : function start(){
 
             var conf = module.config();
             var $container = $(".result-table");
@@ -60,32 +60,15 @@ define([
             var columns = [];
             var groups = {};
 
-            var filterDeStartRange = dateRangeFactory({
-                pickerType: 'datetimepicker',
-                pickerConfig: {
-                    // configurations from lib/jquery.timePicker.js
-                    dateFormat: 'yy-mm-dd',
-                    timeFormat: 'HH:mm:ss'
-                }
-            })
-                .on('render', function () {
+            //setup the date range pickers
+            var filterDeStartRange = dateRangeFactory($dateStartRangeContainer)
+                .on('render', function() {
                     $('button', $dateStartRangeContainer).hide();
-                })
-                .render($dateStartRangeContainer);
-
-            var filterDeEndRange = dateRangeFactory({
-                pickerType: 'datetimepicker',
-                pickerConfig: {
-                    // configurations from lib/jquery.timePicker.js
-                    dateFormat: 'yy-mm-dd',
-                    timeFormat: 'HH:mm:ss'
-                }
-            })
-                .on('render', function () {
+                });
+            var filterDeEndRange = dateRangeFactory($dateEndRangeContainer)
+                .on('render', function() {
                     $('button', $dateEndRangeContainer).hide();
-                })
-                .render($dateEndRangeContainer);
-
+                });
 
             /**
              * Load columns to rebuild the datatable dynamically
@@ -103,9 +86,9 @@ define([
                     if(response && response.columns){
                         if(action === 'remove'){
                             columns = _.reject(columns, function(col){
-                               return _.find(response.columns, function(resCol){
+                                return _.find(response.columns, function(resCol){
                                     return _.isEqual(col, resCol);
-                               });
+                                });
                             });
                         } else {
                             if(typeof response.first !== 'undefined' && response.first === true){
@@ -184,7 +167,7 @@ define([
                 e.preventDefault();
                 buildGrid(url, action, function(){
                     _.forEach(groups[group], function($btn){
-                       $btn.toggleClass('hidden');
+                        $btn.toggleClass('hidden');
                     });
                 });
             });


### PR DESCRIPTION
Linked to https://oat-sa.atlassian.net/browse/TAO-7265 

Replaces the date range component by the new one (that uses the date time picker)
*How to test*
 1. Take a test and submit it
 2. In the `Backoffice` ->  `Results` -> `Export table`
 3. Enter date ranges
![image](https://user-images.githubusercontent.com/468620/55817268-769c8500-5af4-11e9-9ca0-4b802358be82.png)

Please note the filtering doesn't work even without the changes (bug reported) but the values are submitted to the backend (observe the network panel)

*Dependent PR*
 - [x] https://github.com/oat-sa/tao-core/pull/2072