### PR TITLE
Nex 89 modify tao core fe references

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -37,7 +37,7 @@ return [
     'label'          => 'Result visualisation',
     'description'    => 'TAO Results extension',
     'license'        => 'GPL-2.0',
-    'version'        => '7.8.2',
+    'version'        => '7.9.0',
     'author'         => 'Open Assessment Technologies, CRP Henri Tudor',
     // taoItems is only needed for the item model property retrieval
     'requires'       => [

--- a/manifest.php
+++ b/manifest.php
@@ -45,7 +45,7 @@ return [
         'taoResultServer' => '>=7.0.0',
         'taoItems'        => '>=6.0.0',
         'taoDeliveryRdf'  => '>=6.0.0',
-        'tao'             => '>=32.0.0'
+        'tao'             => '>=34.3.0'
     ],
     'install'        => [
         'php' => [

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -182,6 +182,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('7.5.0');
         }
 
-        $this->skip('7.5.0', '7.8.2');
+        $this->skip('7.5.0', '7.9.0');
     }
 }

--- a/views/js/component/results/areaBroker.js
+++ b/views/js/component/results/areaBroker.js
@@ -20,7 +20,7 @@
  */
 define([
     'lodash',
-    'core/areaBroker'
+    'ui/areaBroker'
 ], function (_, areaBroker) {
     'use strict';
 
@@ -31,7 +31,7 @@ define([
     /**
      * Creates an area broker with the required areas for the list of results
      *
-     * @see core/areaBroker
+     * @see ui/areaBroker
      *
      * @param {jQueryElement|HTMLElement|String} $container - the main container
      * @param {Object} mapping - keys are the area names, values are jQueryElement

--- a/views/js/controller/inspectResults.js
+++ b/views/js/controller/inspectResults.js
@@ -12,7 +12,7 @@ define([
     'layout/actions/binder',
     'layout/loading-bar',
     'ui/feedback',
-    'core/taskQueue/taskQueue',
+    'ui/taskQueue/taskQueue',
     'taoOutcomeUi/component/results/pluginsLoader',
     'taoOutcomeUi/component/results/list',
     'ui/taskQueueButton/treeButton'

--- a/views/js/controller/resultTable.js
+++ b/views/js/controller/resultTable.js
@@ -26,7 +26,7 @@ define([
     'module',
     'util/url',
     'ui/feedback',
-    'core/taskQueue/taskQueue',
+    'ui/taskQueue/taskQueue',
     'ui/taskQueueButton/standardButton',
     'ui/dateRange/dateRange',
     'ui/datatable'


### PR DESCRIPTION
This should be merge with: https://github.com/oat-sa/tao-core/pull/2108

Update frontend module references to tao-core:

- core/areaBroker -> ui/areaBroker
- core/validator -> ui/validator
- core/taskQueue -> ui/taskQueue