### PR TITLE
Fix/tao 8678/fixed stuck updater

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -37,7 +37,7 @@ return [
     'label'          => 'Result visualisation',
     'description'    => 'TAO Results extension',
     'license'        => 'GPL-2.0',
-    'version'        => '7.11.1',
+    'version'        => '7.11.2',
     'author'         => 'Open Assessment Technologies, CRP Henri Tudor',
     // taoItems is only needed for the item model property retrieval
     'requires'       => [

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -182,6 +182,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('7.5.0');
         }
 
-        $this->skip('7.5.0', '7.11.1');
+        $this->skip('7.5.0', '7.11.2');
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -124,7 +124,7 @@ class Updater extends \common_ext_ExtensionUpdater
 
         $this->skip('5.5.0', '5.9.2');
 
-        if ($this->isVersion('5.9.2')) {
+        if ($this->isVersion('5.9.2') || $this->isVersion('5.9.2.1')) {
             /** @var TaskLogInterface|ConfigurableService $taskLogService */
             $taskLogService = $this->getServiceManager()->get(TaskLogInterface::SERVICE_ID);
 


### PR DESCRIPTION
Related to https://oat-sa.atlassian.net/browse/TAO-8678

If the last installed extension version is `5.9.2.1` then after code update to a later version the `taoUpdater.php` gets stuck.
This fix is for this specific case, happened with one of the client deployments.