### PR TITLE
TAO-8697 - Replace Calls of singleton method by ServiceManager calls

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -37,7 +37,7 @@ return [
     'label'          => 'Result visualisation',
     'description'    => 'TAO Results extension',
     'license'        => 'GPL-2.0',
-    'version'        => '7.11.1',
+    'version'        => '7.11.2',
     'author'         => 'Open Assessment Technologies, CRP Henri Tudor',
     // taoItems is only needed for the item model property retrieval
     'requires'       => [

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -182,6 +182,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('7.5.0');
         }
 
-        $this->skip('7.5.0', '7.11.1');
+        $this->skip('7.5.0', '7.11.2');
     }
 }

--- a/test/integration/model/ResultsServiceTest.php
+++ b/test/integration/model/ResultsServiceTest.php
@@ -60,8 +60,7 @@ class ResultsServiceTest extends GenerisPhpUnitTestRunner
     public function setUp()
     {
         TaoPhpUnitTestRunner::initTest();
-        common_ext_ExtensionsManager::singleton()->getExtensionById('taoOutcomeUi');
-        $this->service = ResultsService::singleton();
+        $this->service = new ResultsService();
     }
 
     /**


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/TAO-8697
Replace Calls of singleton method by ServiceManager calls

Classes which are extending the OntologyClass ConfigurableService, are retrieved by using the ServiceManager::get() method instead of calling the deprecated singleton method.