### PR TITLE
Fix/tao 8936/lti test taker

### DIFF
--- a/controller/Results.php
+++ b/controller/Results.php
@@ -212,7 +212,7 @@ class Results extends \tao_actions_CommonModule
 
                 $data[] = array(
                     'id' => $deliveryExecution->getIdentifier(),
-                    'ttakerid' => $res['testTakerIdentifier'],
+                    'ttakerid' => $user->getIdentifier(),
                     'ttaker' => _dh($userName),
                     'time' => $startTime,
                 );

--- a/manifest.php
+++ b/manifest.php
@@ -37,7 +37,7 @@ return [
     'label'          => 'Result visualisation',
     'description'    => 'TAO Results extension',
     'license'        => 'GPL-2.0',
-    'version'        => '7.11.4',
+    'version'        => '7.11.5',
     'author'         => 'Open Assessment Technologies, CRP Henri Tudor',
     // taoItems is only needed for the item model property retrieval
     'requires'       => [

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -182,6 +182,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('7.5.0');
         }
 
-        $this->skip('7.5.0', '7.11.4');
+        $this->skip('7.5.0', '7.11.5');
     }
 }


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/TAO-8936

Change Test Taker ID column value for Result page.

Steps To reproduce:
1 Pass test on a client using LTI link.
2 Synk result in cloud
3 Go to result page in server and check test taker id value

Actual result: in Test Taker ID URI lti user which was pushed in server
Expect Result:  in Test Taker ID - user_id from LTI launch data (for other test-takers test taker ID should stay the same)
