### PR TITLE
Fix/export for kv lti users

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -37,7 +37,7 @@ return [
     'label'          => 'Result visualisation',
     'description'    => 'TAO Results extension',
     'license'        => 'GPL-2.0',
-    'version'        => '8.0.0',
+    'version'        => '8.0.1',
     'author'         => 'Open Assessment Technologies, CRP Henri Tudor',
     // taoItems is only needed for the item model property retrieval
     'requires'       => [

--- a/model/ResultsService.php
+++ b/model/ResultsService.php
@@ -1034,7 +1034,11 @@ class ResultsService extends OntologyClassService implements ServiceLocatorAware
                         ? $this->getTestTaker($result)
                         : $this->getDelivery($result);
 
-                    $values = $resource->getPropertyValues($column->getProperty());
+                    $property = $column->getProperty();
+                    if ($resource instanceof User) {
+                        $property = $column->getProperty()->getUri();
+                    }
+                    $values = $resource->getPropertyValues($property);
 
                     $values = array_map(function ($value) use ($column) {
                         if (\common_Utils::isUri($value)) {

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -182,6 +182,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('7.5.0');
         }
 
-        $this->skip('7.5.0', '8.0.0');
+        $this->skip('7.5.0', '8.0.1');
     }
 }


### PR DESCRIPTION
We have found that if KV for User services, not all columns are filled when we do the export of results.
It's because of `getPropertyValues` has different realization for resources and for Users 