### PR TITLE
Fix/ACTP-53/Result of searching in incorrect order

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -38,7 +38,7 @@ return [
     'label'          => 'Result visualisation',
     'description'    => 'TAO Results extension',
     'license'        => 'GPL-2.0',
-    'version'        => '8.3.0',
+    'version'        => '8.3.1',
     'author'         => 'Open Assessment Technologies, CRP Henri Tudor',
     // taoItems is only needed for the item model property retrieval
     'requires'       => [

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -182,6 +182,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('7.5.0');
         }
 
-        $this->skip('7.5.0', '8.3.0');
+        $this->skip('7.5.0', '8.3.1');
     }
 }

--- a/views/js/controller/resultsMonitoring.js
+++ b/views/js/controller/resultsMonitoring.js
@@ -194,7 +194,7 @@ define([
                         label: __('Delivery Execution'),
                         sortable: false,
                     }, {
-                        id: 'testTakerIdentifier',
+                        id: 'userName',
                         label: __('Test Taker'),
                         sortable: false
                     }, {


### PR DESCRIPTION
Result of searching is presented in incorrect order in table.

Related to: [https://oat-sa.atlassian.net/browse/ACTP-53](https://oat-sa.atlassian.net/browse/ACTP-53)
 
Changes:
- **Results monitoring page**: datatable identifier `testTakerIdentifier` was replaced with `userName`;
- **Results monitoring page**: `testTakerIdentifier` value will contain user ID instead of user name;
- **Results monitoring page**: added new response element `userName` which will contain user name; 
- **Results page**: `testTakerIdentifier` value will contain user ID instead of user name (to receive user correctly);
 
#### Precondition:
Switch to elasticsearch with the following command:
```
# ES_* - ElasticSearch

php vendor/oat-sa/lib-tao-elasticsearch/bin/activateElasticSearch.php [PROJECT_ROOT] [ES_SCHEME]://[ES_HOST]:[ES_PORT]
```

#### Steps to reproduce:
- Log as admin.
- Open 'Results' tab.
- Choose specific delivery.
- Enter Resource ID or user name in 'Search by delivery results' field and click sign of searching or press 'Enter' button.
  
#### How to test
**Bug**:
Test taker's name is presented in column 'Test Taker ID', column 'Test Taker' is empty (please, see attachments).
**Fixed**:
Result of searching is presented in correct order in table: 'Test Taker ID' contains ID, 'Test Taker' contains name.