### PR TITLE
Proctorio review event

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -38,7 +38,7 @@ return [
     'label'          => 'Result visualisation',
     'description'    => 'TAO Results extension',
     'license'        => 'GPL-2.0',
-    'version'        => '8.6.1',
+    'version'        => '8.7.0',
     'author'         => 'Open Assessment Technologies, CRP Henri Tudor',
     // taoItems is only needed for the item model property retrieval
     'requires'       => [

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -182,7 +182,7 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('7.5.0');
         }
 
-        $this->skip('7.5.0', '8.6.1');
+        $this->skip('7.5.0', '8.7.0');
 
     }
 }

--- a/views/js/controller/inspectResults.js
+++ b/views/js/controller/inspectResults.js
@@ -31,7 +31,7 @@ define([
 
         logger.error(err);
 
-        if (err instanceof Error) {
+        if (err instanceof Error) {s
             feedback().error(err.message);
         }
     }
@@ -107,17 +107,17 @@ define([
                 }).start();
             });
 
-            binder.register('proctorio_url_redirect', function(actionContext) {
+            binder.register('open_url', function(actionContext) {
                 const data = _.pick(actionContext, ['uri', 'classUri', 'id']);
 
-                request(this.url, {...data},'POST')
+                request(this.url, data,'POST')
                     .then(response => {
                         const url = response.url;
 
                         if (url) {
                             window.open(url, '_blank');
                         } else {
-                            feedback().info(__('Proctorio review link is not generated because there are no executions for this delivery yet.'));
+                            feedback().info(__('The URL does not exist.'));
                         }
                     })
                     .catch(err => {

--- a/views/js/controller/inspectResults.js
+++ b/views/js/controller/inspectResults.js
@@ -110,7 +110,7 @@ define([
             binder.register('open_url', function(actionContext) {
                 const data = _.pick(actionContext, ['uri', 'classUri', 'id']);
 
-                request(this.url, data,'POST')
+                request(this.url, data, 'POST')
                     .then(response => {
                         const url = response.url;
 
@@ -120,9 +120,7 @@ define([
                             feedback().info(__('The URL does not exist.'));
                         }
                     })
-                    .catch(err => {
-                        reportError(err);
-                    });
+                    .catch(reportError);
             });
         }
     };

--- a/views/js/controller/inspectResults.js
+++ b/views/js/controller/inspectResults.js
@@ -21,7 +21,6 @@ define([
     'use strict';
 
     var logger = loggerFactory('controller/inspectResults');
-    var reviewUrl = urlHelper.route('review', 'DeliveryReview', 'remoteProctoring');
 
     /**
      * Take care of errors
@@ -108,10 +107,10 @@ define([
                 }).start();
             });
 
-            binder.register('proctorio_url_redirect', actionContext => {
+            binder.register('proctorio_url_redirect', function(actionContext) {
                 const data = _.pick(actionContext, ['uri', 'classUri', 'id']);
 
-                request(reviewUrl, {...data},'POST')
+                request(this.url, {...data},'POST')
                     .then(response => {
                         const url = response.url;
 

--- a/views/js/controller/inspectResults.js
+++ b/views/js/controller/inspectResults.js
@@ -8,6 +8,7 @@ define([
     'i18n',
     'module',
     'core/logger',
+    'core/dataProvider/request',
     'util/url',
     'layout/actions/binder',
     'layout/loading-bar',
@@ -16,10 +17,11 @@ define([
     'taoOutcomeUi/component/results/pluginsLoader',
     'taoOutcomeUi/component/results/list',
     'ui/taskQueueButton/treeButton'
-], function ($, _, __, module, loggerFactory, urlHelper, binder, loadingBar, feedback, taskQueue, resultsPluginsLoader, resultsListFactory, treeTaskButtonFactory) {
+], function ($, _, __, module, loggerFactory, request, urlHelper, binder, loadingBar, feedback, taskQueue, resultsPluginsLoader, resultsListFactory, treeTaskButtonFactory) {
     'use strict';
 
     var logger = loggerFactory('controller/inspectResults');
+    var reviewUrl = urlHelper.route('review', 'DeliveryReview', 'remoteProctoring');
 
     /**
      * Take care of errors
@@ -104,6 +106,24 @@ define([
                     taskCreationUrl : this.url,
                     taskCreationData : {uri : uniqueValue}
                 }).start();
+            });
+
+            binder.register('proctorio_url_redirect', actionContext => {
+                const data = _.pick(actionContext, ['uri', 'classUri', 'id']);
+
+                request(reviewUrl, {...data},'POST')
+                    .then(response => {
+                        const url = response.url;
+
+                        if (url) {
+                            window.open(url, '_blank');
+                        } else {
+                            feedback().info(__('Proctorio review link is not generated because there are no executions for this delivery yet.'));
+                        }
+                    })
+                    .catch(err => {
+                        reportError(err);
+                    });
             });
         }
     };


### PR DESCRIPTION
Ticket: https://oat-sa.atlassian.net/browse/NEX-882

**What's changed?**

I have added a new event which is registered when you go to the results page. This event is bound to the action in remoteProctorio structures.xml

_I am not really satisfied with this solution because we are adding a piece of code in taoOutcomeUi which is related to remoteProctoring but I couldn't find an appropriate place to register this method. Your suggestion is appreciated._

Related PR: https://github.com/oat-sa/extension-remote-proctoring/pull/18

**How to test?**

- Have a tao instance with Proctorio ready
- Create a test and publish the delivery with remote proctoring enabled
- Execute the test
- Go to the results page as an admin
- Select the delivery and click on review proctorio button to open the proctorio review link in a new tab