### PR TITLE
Feature/nec 86/drawing coordinates available to test taker responses

### DIFF
--- a/helper/ResponseVariableFormatter.php
+++ b/helper/ResponseVariableFormatter.php
@@ -92,6 +92,7 @@ class ResponseVariableFormatter
     {
         $value = $var->getValue();
         switch ($var->getCardinality()) {
+            case 'record':
             case 'single':
                 if (strlen($value) === 0) {
                     $formatted = ['base' => null];

--- a/manifest.php
+++ b/manifest.php
@@ -38,7 +38,7 @@ return [
     'label'          => 'Result visualisation',
     'description'    => 'TAO Results extension',
     'license'        => 'GPL-2.0',
-    'version'        => '8.7.0',
+    'version'        => '8.7.1',
     'author'         => 'Open Assessment Technologies, CRP Henri Tudor',
     // taoItems is only needed for the item model property retrieval
     'requires'       => [

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -182,7 +182,7 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('7.5.0');
         }
 
-        $this->skip('7.5.0', '8.7.0');
+        $this->skip('7.5.0', '8.7.1');
 
     }
 }

--- a/test/integration/helper/ResponseVariableFormatterTest.php
+++ b/test/integration/helper/ResponseVariableFormatterTest.php
@@ -61,6 +61,18 @@ class ResponseVariableFormatterTest extends TestCase
         $this->assertEquals($expected, ResponseVariableFormatter::formatVariableToPci($var));
     }
 
+    public function testFormatRecordIdentifier()
+    {
+        $var = new ResponseVariable();
+        $var->setBaseType('identifier');
+        $var->setCardinality('record');
+        $var->setValue('ABC');
+
+        $expected = ['base' => ['identifier' => 'ABC']];
+
+        $this->assertEquals($expected, ResponseVariableFormatter::formatVariableToPci($var));
+    }
+
     public function testFormatSinglePair()
     {
         $var = new ResponseVariable();


### PR DESCRIPTION
___Related to task:___ https://oat-sa.atlassian.net/browse/NEC-86

___Description:___ Drawing coordinates available to test-taker responses

The object of the result of the response to the Drawing coordinates interaction has a QTI Record Cardinality type that is not considered in the ResponseVariableFormatterTest