### PR TITLE
Fix/lti launch

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -38,7 +38,7 @@ return [
     'label'          => 'Result visualisation',
     'description'    => 'TAO Results extension',
     'license'        => 'GPL-2.0',
-    'version'        => '8.7.3',
+    'version'        => '8.7.4',
     'author'         => 'Open Assessment Technologies, CRP Henri Tudor',
     // taoItems is only needed for the item model property retrieval
     'requires'       => [

--- a/model/search/ResultsWatcher.php
+++ b/model/search/ResultsWatcher.php
@@ -101,7 +101,6 @@ class ResultsWatcher extends ConfigurableService
             ];
             $body = array_merge($body, $customBody);
             $queueDispatcher = $this->getServiceLocator()->get(QueueDispatcherInterface::SERVICE_ID);
-            $queueDispatcher->setOwner('Index');
             $queueDispatcher->createTask(new AddSearchIndexFromArray(), [$id, $body], __('Adding/Updating search index for %s', $deliveryExecution->getLabel()));
         }
         return $report;

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -182,7 +182,7 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('7.5.0');
         }
 
-        $this->skip('7.5.0', '8.7.3');
+        $this->skip('7.5.0', '8.7.4');
 
     }
 }


### PR DESCRIPTION
When the system is configured with elastic-search but without taskqueue, the queue is executed in real time. During the execution of the task, the session of the user will be killed and replaced with a session beloning to a fake user "Indexer". This triggers errors during the run of the test later