### PR TITLE
Fix/ncsup 275/empty csv result export

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -39,7 +39,7 @@ return [
     'label'          => 'Result visualisation',
     'description'    => 'TAO Results extension',
     'license'        => 'GPL-2.0',
-    'version'        => '9.4.1',
+    'version'        => '9.4.2',
     'author'         => 'Open Assessment Technologies, CRP Henri Tudor',
     // taoItems is only needed for the item model property retrieval
     'requires'       => [

--- a/model/ResultsService.php
+++ b/model/ResultsService.php
@@ -1123,6 +1123,10 @@ class ResultsService extends OntologyClassService
         $rows = [];
         $dataProviderMap = $this->collectColumnDataProviderMap($columns);
 
+        if (!array_key_exists($offset, $results)) {
+            return null;
+        }
+
         /** @var DeliveryExecution $result */
         for ($i = $offset; $i < ($offset + $limit); $i++) {
             if (!array_key_exists($i, $results)) {

--- a/model/export/SingleDeliveryResultsExporter.php
+++ b/model/export/SingleDeliveryResultsExporter.php
@@ -92,7 +92,7 @@ class SingleDeliveryResultsExporter implements ResultsExporterInterface
      */
     private $filters = [];
 
-    const CHUNK_SIZE = 1;
+    const CHUNK_SIZE = 100;
 
     /**
      * @param string|\core_kernel_classes_Resource $delivery

--- a/model/export/SingleDeliveryResultsExporter.php
+++ b/model/export/SingleDeliveryResultsExporter.php
@@ -92,7 +92,7 @@ class SingleDeliveryResultsExporter implements ResultsExporterInterface
      */
     private $filters = [];
 
-    const CHUNK_SIZE = 100;
+    const CHUNK_SIZE = 1;
 
     /**
      * @param string|\core_kernel_classes_Resource $delivery
@@ -241,6 +241,10 @@ class SingleDeliveryResultsExporter implements ResultsExporterInterface
             PHP_INT_MAX
         );
 
+        if ($cells === null) {
+            $cells = [];
+        }
+
         // flattening data: only 'cell' is what we need
         return array_map(function ($row) {
             return $row['cell'];
@@ -278,6 +282,9 @@ class SingleDeliveryResultsExporter implements ResultsExporterInterface
             $limit
         );
 
+        if ($cells === null) {
+            return null;
+        }
         // flattening data: only 'cell' is what we need
         return array_map(function ($row) {
             return $row['cell'];
@@ -305,7 +312,9 @@ class SingleDeliveryResultsExporter implements ResultsExporterInterface
         do {
             $cells = $this->getCells($data, $offset, self::CHUNK_SIZE);
             $offset += self::CHUNK_SIZE;
-
+            if ($cells === null) {
+                break;
+            }
             foreach ($cells as $row) {
                 $rowResult = [];
                 foreach ($row as $rowKey => $rowVal) {
@@ -313,7 +322,7 @@ class SingleDeliveryResultsExporter implements ResultsExporterInterface
                 }
                 $result[] = $rowResult;
             }
-        } while (count($cells));
+        } while ($cells !== null);
 
         $this->sortByStartDate($result);
 

--- a/test/unit/model/ResultsServiceTest.php
+++ b/test/unit/model/ResultsServiceTest.php
@@ -367,6 +367,12 @@ class ResultsServiceTest extends TestCase
         self::assertSame($expected, $method->invokeArgs($resultsService, [$row, $filters]));
     }
 
+    public function testGetCellsByResults()
+    {
+        $service = new ResultsService();
+        $this->assertEquals(null, $service->getCellsByResults([], [], []));
+    }
+
     private function getResponseVariable(
         $candidateResponse = 'UFQ0LjA5MTc1M1M=',
         $identifier = 'duration',


### PR DESCRIPTION
When first chunk returns empty array do/while loop breaks and other chunks are not processed.

To reproduce the issue change `oat\taoOutcomeUi\model\export\SingleDeliveryResultsExporter::CHUNK_SIZE` to 1 and try to export csv file filtered by start date. Set the `Start Delivery Execution:From` filter value *after* start time of the first delivery exectuion.