### PR TITLE
Feature/CON-76/check saved delivery result id and load it

### DIFF
--- a/model/search/ResultsWatcher.php
+++ b/model/search/ResultsWatcher.php
@@ -41,12 +41,16 @@ class ResultsWatcher extends ConfigurableService
 {
     use OntologyAwareTrait;
 
-    const SERVICE_ID = 'taoOutcomeUi/ResultsWatcher';
-    const INDEX_DELIVERY = 'delivery';
-    const INDEX_TEST_TAKER = 'test_taker';
-    const INDEX_TEST_TAKER_NAME = 'test_taker_name';
-    const INDEX_DELIVERY_EXECUTION = 'delivery_execution';
-    const OPTION_RESULT_SEARCH_FIELD_VISIBILITY = 'option_result_search_field_visibility';
+    public const SERVICE_ID = 'taoOutcomeUi/ResultsWatcher';
+    public const OPTION_RESULT_SEARCH_FIELD_VISIBILITY = 'option_result_search_field_visibility';
+
+    public const INDEX_DELIVERY = 'delivery';
+    public const INDEX_TEST_TAKER = 'test_taker';
+    public const INDEX_TEST_TAKER_NAME = 'test_taker_name';
+    public const INDEX_DELIVERY_EXECUTION = 'delivery_execution';
+    public const INDEX_DELIVERY_EXECUTION_START_TIME = 'delivery_execution_start_time';
+    public const INDEX_TEST_TAKER_LAST_NAME = 'test_taker_last_name';
+    public const INDEX_TEST_TAKER_FIRST_NAME = 'test_taker_first_name';
 
     /**
      * @param DeliveryExecutionCreated $event
@@ -86,22 +90,30 @@ class ResultsWatcher extends ConfigurableService
         $report = \common_report_Report::createSuccess();
         $searchService = $this->getServiceLocator()->get(Search::SERVICE_ID);
         if ($searchService->supportCustomIndex()) {
-            $id = $deliveryExecution->getIdentifier();
+            $deliveryExecutionId = $deliveryExecution->getIdentifier();
             $user = UserHelper::getUser($deliveryExecution->getUserIdentifier());
             $customFieldService = $this->getServiceLocator()->get(ResultCustomFieldsService::SERVICE_ID);
             $customBody = $customFieldService->getCustomFields($deliveryExecution);
-            $userName = UserHelper::getUserName($user, true);
+
             $body = [
                 'label' => $deliveryExecution->getLabel(),
                 self::INDEX_DELIVERY => $deliveryExecution->getDelivery()->getUri(),
                 'type' => ResultService::DELIVERY_RESULT_CLASS_URI,
                 self::INDEX_TEST_TAKER => $user->getIdentifier(),
-                self::INDEX_TEST_TAKER_NAME => $userName,
-                self::INDEX_DELIVERY_EXECUTION => $id,
+                self::INDEX_TEST_TAKER_FIRST_NAME => UserHelper::getUserFirstName($user, true),
+                self::INDEX_TEST_TAKER_LAST_NAME => UserHelper::getUserLastName($user, true),
+                self::INDEX_TEST_TAKER_NAME => UserHelper::getUserName($user, true),
+                self::INDEX_DELIVERY_EXECUTION => $deliveryExecutionId,
+                self::INDEX_DELIVERY_EXECUTION_START_TIME => (string) $deliveryExecution->getStartTime()
             ];
             $body = array_merge($body, $customBody);
             $queueDispatcher = $this->getServiceLocator()->get(QueueDispatcherInterface::SERVICE_ID);
-            $queueDispatcher->createTask(new AddSearchIndexFromArray(), [$id, $body], __('Adding/Updating search index for %s', $deliveryExecution->getLabel()));
+
+            $queueDispatcher->createTask(
+                new AddSearchIndexFromArray(),
+                [$deliveryExecutionId, $body],
+                __('Adding/Updating search index for %s', $deliveryExecution->getLabel())
+            );
         }
         return $report;
     }

--- a/model/search/ResultsWatcher.php
+++ b/model/search/ResultsWatcher.php
@@ -140,7 +140,9 @@ class ResultsWatcher extends ConfigurableService
         }
 
         if (!$date instanceof DateTime) {
-            $this->logCritical('We wer not able to transform delivery-execution start time!');
+            $this->logCritical(
+                sprintf('We were not able to transform string: "%s" delivery-execution start time!', $getStartTime)
+            );
             return '';
         }
 

--- a/model/search/ResultsWatcher.php
+++ b/model/search/ResultsWatcher.php
@@ -141,7 +141,7 @@ class ResultsWatcher extends ConfigurableService
 
         if (!$date instanceof DateTime) {
             $this->logCritical('We wer not able to transform delivery-execution start time!');
-            return 'wrong data';
+            return '';
         }
 
         return $date->format('m/d/Y H:i:s');

--- a/model/search/ResultsWatcher.php
+++ b/model/search/ResultsWatcher.php
@@ -15,12 +15,12 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2018 (original work) Open Assessment Technologies SA;
- *
+ * Copyright (c) 2018-2020 (original work) Open Assessment Technologies SA;
  */
 
 namespace oat\taoOutcomeUi\model\search;
 
+use DateTime;
 use DateTimeImmutable;
 use oat\generis\model\OntologyAwareTrait;
 use oat\oatbox\service\ConfigurableService;
@@ -134,6 +134,16 @@ class ResultsWatcher extends ConfigurableService
     {
         $timeArray = explode(" ", $getStartTime);
         $date = DateTimeImmutable::createFromFormat('U', $timeArray[1]);
+
+        if ($date === false) {
+            $date = DateTimeImmutable::createFromFormat('Y-m-d H:i:s', $getStartTime);
+        }
+
+        if (!$date instanceof DateTime) {
+            $this->logCritical('We wer not able to transform delivery-execution start time!');
+            return 'wrong data';
+        }
+
         return $date->format('m/d/Y H:i:s');
     }
 }

--- a/model/search/ResultsWatcher.php
+++ b/model/search/ResultsWatcher.php
@@ -21,6 +21,7 @@
 
 namespace oat\taoOutcomeUi\model\search;
 
+use DateTimeImmutable;
 use oat\generis\model\OntologyAwareTrait;
 use oat\oatbox\service\ConfigurableService;
 use oat\tao\helpers\UserHelper;
@@ -104,7 +105,9 @@ class ResultsWatcher extends ConfigurableService
                 self::INDEX_TEST_TAKER_LAST_NAME => UserHelper::getUserLastName($user, true),
                 self::INDEX_TEST_TAKER_NAME => UserHelper::getUserName($user, true),
                 self::INDEX_DELIVERY_EXECUTION => $deliveryExecutionId,
-                self::INDEX_DELIVERY_EXECUTION_START_TIME => (string) $deliveryExecution->getStartTime()
+                self::INDEX_DELIVERY_EXECUTION_START_TIME =>  $this->transformDateTime(
+                    $deliveryExecution->getStartTime()
+                )
             ];
             $body = array_merge($body, $customBody);
             $queueDispatcher = $this->getServiceLocator()->get(QueueDispatcherInterface::SERVICE_ID);
@@ -125,5 +128,12 @@ class ResultsWatcher extends ConfigurableService
     public function isResultSearchEnabled()
     {
         return (bool)$this->getOption(self::OPTION_RESULT_SEARCH_FIELD_VISIBILITY);
+    }
+
+    private function transformDateTime(string $getStartTime): string
+    {
+        $timeArray = explode(" ", $getStartTime);
+        $date = DateTimeImmutable::createFromFormat('U', $timeArray[1]);
+        return $date->format('m/d/Y H:i:s');
     }
 }

--- a/views/js/controller/inspectResults.js
+++ b/views/js/controller/inspectResults.js
@@ -17,7 +17,22 @@ define([
     'taoOutcomeUi/component/results/pluginsLoader',
     'taoOutcomeUi/component/results/list',
     'ui/taskQueueButton/treeButton'
-], function ($, _, __, module, loggerFactory, request, urlHelper, binder, loadingBar, feedback, taskQueue, resultsPluginsLoader, resultsListFactory, treeTaskButtonFactory) {
+], function (
+    $,
+    _,
+    __,
+    module,
+    loggerFactory,
+    request,
+    urlHelper,
+    binder,
+    loadingBar,
+    feedback,
+    taskQueue,
+    resultsPluginsLoader,
+    resultsListFactory,
+    treeTaskButtonFactory
+) {
     'use strict';
 
     var logger = loggerFactory('controller/inspectResults');
@@ -40,7 +55,6 @@ define([
      * @exports taoOutcomeUi/controller/resultTable
      */
     return {
-
         /**
          * Controller entry point
          */
@@ -48,6 +62,20 @@ define([
             var config = module.config() || {};
             var $container = $('#inspect-result');
             var classUri = $container.data('uri');
+            const searchContainer = $('.action-bar .search-area');
+            if (searchContainer.data('show-result')) {
+                var action = {
+                    binding: 'load',
+                    url: urlHelper.route('viewResult', 'Results', 'taoOutcomeUi')
+                };
+                var context = {
+                    id: searchContainer.data('show-result'),
+                    classUri
+                };
+                searchContainer.removeData('show-result');
+                binder.exec(action, context);
+                return;
+            }
             var listConfig = {
                 dataUrl: urlHelper.route('getResults', 'Results', 'taoOutcomeUi', {
                     classUri: classUri
@@ -72,14 +100,15 @@ define([
             });
 
             if ($container.length) {
-                resultsPluginsLoader.load()
+                resultsPluginsLoader
+                    .load()
                     .then(function () {
                         resultsListFactory(listConfig, resultsPluginsLoader.getPlugins())
                             .on('error', reportError)
                             .on('success', function (message) {
                                 feedback().success(message);
                             })
-                            .before('loading', function() {
+                            .before('loading', function () {
                                 loadingBar.start();
                             })
                             .after('loaded', function () {
@@ -93,19 +122,21 @@ define([
             }
 
             taskButton = treeTaskButtonFactory({
-                replace : true,
-                icon : 'export',
-                label : __('Export CSV'),
-                taskQueue : taskQueue
+                replace: true,
+                icon: 'export',
+                label: __('Export CSV'),
+                taskQueue: taskQueue
             }).render($('#results-csv-export'));
 
-            binder.register('export_csv', function remove(actionContext){
+            binder.register('export_csv', function remove(actionContext) {
                 var data = _.pick(actionContext, ['uri', 'classUri', 'id']);
                 var uniqueValue = data.uri || data.classUri || '';
-                taskButton.setTaskConfig({
-                    taskCreationUrl : this.url,
-                    taskCreationData : {uri : uniqueValue}
-                }).start();
+                taskButton
+                    .setTaskConfig({
+                        taskCreationUrl: this.url,
+                        taskCreationData: { uri: uniqueValue }
+                    })
+                    .start();
             });
 
             if ($('#results-sql-export').length) {
@@ -119,14 +150,16 @@ define([
                 binder.register('export_sql', function remove(actionContext) {
                     var data = _.pick(actionContext, ['uri', 'classUri', 'id']);
                     var uniqueValue = data.uri || data.classUri || '';
-                    taskButtonExportSQL.setTaskConfig({
-                        taskCreationUrl: this.url,
-                        taskCreationData: {uri: uniqueValue}
-                    }).start();
+                    taskButtonExportSQL
+                        .setTaskConfig({
+                            taskCreationUrl: this.url,
+                            taskCreationData: { uri: uniqueValue }
+                        })
+                        .start();
                 });
             }
 
-            binder.register('open_url', function(actionContext) {
+            binder.register('open_url', function (actionContext) {
                 const data = _.pick(actionContext, ['uri', 'classUri', 'id']);
 
                 request(this.url, data, 'POST')


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/CON-76
https://github.com/oat-sa/lib-tao-elasticsearch/pull/40
https://github.com/oat-sa/tao-core/pull/2743

FE part: changes in `views/js/controller/inspectResults.js`:
BE part: changes in `model/search/ResultsWatcher.php`

1. controller checking `searchComponent.container.data('show-result')` and if delivery result is stored it will be loaded instead of all results

2. Add missing indexes to result elastic search map.

How to test:
- go to Results page
- run search (use delivery name or test taker name)
- in searchModal should be hidden `add criteria` button and resource selector
- check table with search results and press `Go To Item`
- delivery result should be loaded 