### PR TITLE
Add the delivery class export script

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -39,7 +39,7 @@ return [
     'label'          => 'Result visualisation',
     'description'    => 'TAO Results extension',
     'license'        => 'GPL-2.0',
-    'version'        => '9.4.3',
+    'version'        => '9.5.0',
     'author'         => 'Open Assessment Technologies, CRP Henri Tudor',
     // taoItems is only needed for the item model property retrieval
     'requires'       => [

--- a/scripts/task/ExportDeliveryClassXmlResults.php
+++ b/scripts/task/ExportDeliveryClassXmlResults.php
@@ -20,6 +20,8 @@ class ExportDeliveryClassXmlResults extends ScriptAction
 {
     use OntologyAwareTrait;
 
+    private const ITERATIONS_TO_RELOAD = 100;
+
     /**
      * @var Report
      */
@@ -66,27 +68,27 @@ class ExportDeliveryClassXmlResults extends ScriptAction
         $deliveryClass = $this->getClass($class);
         $resultCount = 0;
 
-        $fileName = \tao_helpers_Display::textCleaner($zipFilenamePrefix) .'-'. time() . '.zip';
-        $path = \tao_helpers_File::concat([\tao_helpers_Export::getExportPath(), $fileName]);
+        try {
+            $fileName = \tao_helpers_Display::textCleaner($zipFilenamePrefix) . '-' . time() . '.zip';
+            $path = \tao_helpers_File::concat([\tao_helpers_Export::getExportPath(), $fileName]);
 
-        if (!\tao_helpers_File::securityCheck($path, true)) {
-            throw new \Exception('Unauthorized file name');
-        }
-        if (file_exists($path)) {
-            unlink($path);
-        }
-        $zipArchive = new \ZipArchive();
-        if ($zipArchive->open($path, \ZipArchive::CREATE) !== true) {
-            throw new \Exception('Unable to create archive at ' . $path);
-        }
+            if (!\tao_helpers_File::securityCheck($path, true)) {
+                throw new \Exception('Unauthorized file name');
+            }
+            if (file_exists($path)) {
+                unlink($path);
+            }
+            $zipArchive = new \ZipArchive();
+            if ($zipArchive->open($path, \ZipArchive::CREATE) !== true) {
+                throw new \Exception('Unable to create archive at ' . $path);
+            }
 
-        $deliveryNumber = 0;
-        $executionAcrossDeliveriesNumber = 0;
-        foreach ($deliveryClass->getInstances(true) as $delivery) {
-            $deliveryNumber++;
-            $this->report->add(Report::createInfo(sprintf('Starting to process delivery "%s"', $delivery->getLabel())));
+            $deliveryNumber = 0;
+            $executionAcrossDeliveriesNumber = 0;
+            foreach ($deliveryClass->getInstances(true) as $delivery) {
+                $deliveryNumber++;
+                $this->report->add(Report::createInfo(sprintf('Starting to process delivery "%s"', $delivery->getLabel())));
 
-            try {
                 $executions = $this->getResultsService()->getResultsByDelivery($delivery);
 
                 $this->report->add(Report::createInfo(sprintf('%d results were found for delivery "%s"', count($executions), $delivery->getLabel())));
@@ -98,7 +100,7 @@ class ExportDeliveryClassXmlResults extends ScriptAction
 
                     // flush the archive by creating the object ZipArchive from scratch every 100 iterations to
                     // prevent ZipArchive from memory leaking (it builds up all the changes in memory that are not 'committed')
-                    if ($executionAcrossDeliveriesNumber % 100 === 0) {
+                    if ($executionAcrossDeliveriesNumber % self::ITERATIONS_TO_RELOAD === 0) {
                         $zipArchive->close();
                         $zipArchive = new \ZipArchive();
 
@@ -116,12 +118,12 @@ class ExportDeliveryClassXmlResults extends ScriptAction
                     $zipArchive->addFromString('results/' . $delivery->getLabel() . '/' . $xmlfileName, $xml);
                     $resultCount++;
                 }
-            } catch (\Exception $e) {
-                if (isset($execution)) {
-                    $this->report->add(Report::createFailure(sprintf('Exception thrown while processing execution "%s": %s', $execution, $e->getMessage())));
-                } else {
-                    $this->report->add(Report::createFailure($e->getMessage()));
-                }
+            }
+        } catch (\Throwable $e) {
+            if (isset($execution)) {
+                $this->report->add(Report::createFailure(sprintf('Exception thrown while processing execution "%s": %s', $execution, $e->getMessage())));
+            } else {
+                $this->report->add(Report::createFailure($e->getMessage()));
             }
         }
         $this->report->add(Report::createSuccess(sprintf('Done! %d results for %d deliveries were exported. Please download the ZIP file at this path: %s', $resultCount, $deliveryNumber, $path)));

--- a/scripts/task/ExportDeliveryClassXmlResults.php
+++ b/scripts/task/ExportDeliveryClassXmlResults.php
@@ -128,14 +128,10 @@ class ExportDeliveryClassXmlResults extends ScriptAction
      */
     private function instantiateZip($path, $create = false)
     {
-        $flags = null;
-        if ($create) {
-            $flags = \ZipArchive::CREATE;
-        }
-
         $zipArchive = new \ZipArchive();
 
-        $zipOpenResult = $zipArchive->open($path, $flags);
+        $zipOpenResult = $create ? $zipArchive->open($path, \ZipArchive::CREATE) : $zipArchive->open($path);
+
         if ($zipOpenResult !== true) {
             throw new \Exception(sprintf('Unable to create archive at path %s (error code %s)', $path, $zipOpenResult));
         }

--- a/scripts/task/ExportDeliveryClassXmlResults.php
+++ b/scripts/task/ExportDeliveryClassXmlResults.php
@@ -95,9 +95,6 @@ class ExportDeliveryClassXmlResults extends ScriptAction
                 foreach ($executions as $execution) {
                     $executionNumber++;
                     $executionAcrossDeliveriesNumber++;
-                    if ($executionNumber == 10) {
-                        break;
-                    }
 
                     // flush the archive by creating the object ZipArchive from scratch every 100 iterations to
                     // prevent ZipArchive from memory leaking (it builds up all the changes in memory that are not 'committed')

--- a/scripts/task/ExportDeliveryClassXmlResults.php
+++ b/scripts/task/ExportDeliveryClassXmlResults.php
@@ -20,7 +20,7 @@ class ExportDeliveryClassXmlResults extends ScriptAction
 {
     use OntologyAwareTrait;
 
-    private const ITERATIONS_TO_RELOAD = 100;
+    private const EXECUTION_ITERATIONS_TO_REINSTANTIATE_ZIP_OBJECT = 100;
 
     /**
      * @var Report
@@ -97,7 +97,7 @@ class ExportDeliveryClassXmlResults extends ScriptAction
 
                     // flush the archive by creating the object ZipArchive from scratch every 100 iterations to
                     // prevent ZipArchive from memory leaking (it builds up all the changes in memory that are not 'committed')
-                    if ($executionAcrossDeliveriesNumber % self::ITERATIONS_TO_RELOAD === 0) {
+                    if ($executionAcrossDeliveriesNumber % self::EXECUTION_ITERATIONS_TO_REINSTANTIATE_ZIP_OBJECT === 0) {
                         $zipArchive->close();
                         $zipArchive = $this->instantiateZip($path);
                     }

--- a/scripts/task/ExportDeliveryClassXmlResults.php
+++ b/scripts/task/ExportDeliveryClassXmlResults.php
@@ -1,0 +1,170 @@
+<?php
+
+namespace oat\taoOutcomeUi\scripts\task;
+
+use common_report_Report as Report;
+use oat\generis\model\OntologyAwareTrait;
+use oat\oatbox\extension\script\ScriptAction;
+use oat\taoDelivery\model\execution\ServiceProxy;
+use oat\taoOutcomeUi\model\ResultsService;
+use oat\taoResultServer\models\classes\QtiResultsService;
+
+/**
+ * Run example:
+ *
+ * http://www.tao.lu/Ontologies/TAODelivery.rdf\#AssembledDelivery
+ * sudo -u www-data php index.php 'oat\taoOutcomeUi\scripts\task\ExportDeliveryClassXmlResults' -u {deliveryClassUri}
+ *
+ */
+class ExportDeliveryClassXmlResults extends ScriptAction
+{
+    use OntologyAwareTrait;
+
+    /**
+     * @var Report
+     */
+    private $report;
+
+    protected function provideOptions()
+    {
+        return [
+            'deliveryClassUri' => [
+                'prefix' => 'u',
+                'longPrefix' => 'uri',
+                'required' => true,
+                'description' => 'Delivery Class URI.'
+            ],
+            'zipFilenamePrefix' => [
+                'prefix' => 'p',
+                'longPrefix' => 'filename_prefix',
+                'required' => false,
+                'defaultValue' => 'xml_results',
+                'description' => 'Prefix for ZIP file name'
+            ],
+        ];
+    }
+
+    protected function provideDescription()
+    {
+        return 'The script will generate a zip with xml results';
+    }
+
+    protected function provideUsage()
+    {
+        return [
+            'prefix' => 'h',
+            'longPrefix' => 'help',
+        ];
+    }
+
+    protected function run()
+    {
+        $this->report = Report::createInfo('Export started');
+
+        $class = $this->getOption('deliveryClassUri');
+        $zipFilenamePrefix = $this->getOption('zipFilenamePrefix');
+        $deliveryClass = $this->getClass($class);
+        $resultCount = 0;
+
+        $fileName = \tao_helpers_Display::textCleaner($zipFilenamePrefix) .'-'. time() . '.zip';
+        $path = \tao_helpers_File::concat([\tao_helpers_Export::getExportPath(), $fileName]);
+
+        if (!\tao_helpers_File::securityCheck($path, true)) {
+            throw new \Exception('Unauthorized file name');
+        }
+        if (file_exists($path)) {
+            unlink($path);
+        }
+        $zipArchive = new \ZipArchive();
+        if ($zipArchive->open($path, \ZipArchive::CREATE) !== true) {
+            throw new \Exception('Unable to create archive at ' . $path);
+        }
+
+        $deliveryNumber = 0;
+        $executionAcrossDeliveriesNumber = 0;
+        foreach ($deliveryClass->getInstances(true) as $delivery) {
+            $deliveryNumber++;
+            $this->report->add(Report::createInfo(sprintf('Starting to process delivery "%s"', $delivery->getLabel())));
+
+            try {
+                $executions = $this->getResultsService()->getResultsByDelivery($delivery);
+
+                $this->report->add(Report::createInfo(sprintf('%d results were found for delivery "%s"', count($executions), $delivery->getLabel())));
+
+                $executionNumber = 0;
+                foreach ($executions as $execution) {
+                    $executionNumber++;
+                    $executionAcrossDeliveriesNumber++;
+                    if ($executionNumber == 10) {
+                        break;
+                    }
+
+                    // flush the archive by creating the object ZipArchive from scratch every 100 iterations to
+                    // prevent ZipArchive from memory leaking (it builds up all the changes in memory that are not 'committed')
+                    if ($executionAcrossDeliveriesNumber % 100 === 0) {
+                        $zipArchive->close();
+                        $zipArchive = new \ZipArchive();
+
+                        if ($zipArchive->open($path) !== true) {
+                            throw new \Exception('Unable to open archive at ' . $path);
+                        }
+                    }
+                    $xml = $this->getQtiResultsService()->getQtiResultXml($delivery->getUri(), $execution);
+                    $executionObj = $this->getServiceProxy()->getDeliveryExecution($execution);
+
+                    $userId = $executionObj->getUserIdentifier();
+                    $xmlfileName = \common_Utils::isUri($userId) ? explode('#', $userId)[1] : $userId;
+                    $xmlfileName .= '.xml';
+
+                    $zipArchive->addFromString('results/' . $delivery->getLabel() . '/' . $xmlfileName, $xml);
+                    $resultCount++;
+                }
+            } catch (\Exception $e) {
+                if (isset($execution)) {
+                    $this->report->add(Report::createFailure(sprintf('Exception thrown while processing execution "%s": %s', $execution, $e->getMessage())));
+                } else {
+                    $this->report->add(Report::createFailure($e->getMessage()));
+                }
+            }
+        }
+        $this->report->add(Report::createSuccess(sprintf('Done! %d results for %d deliveries were exported. Please download the ZIP file at this path: %s', $resultCount, $deliveryNumber, $path)));
+        return $this->report;
+    }
+
+    /**
+     * Get the temp export directory, before the final transfer
+     *
+     * @return string
+     */
+    protected function getTempExportDir()
+    {
+        return \tao_helpers_Export::getExportPath();
+    }
+
+    /**
+     * @return ServiceProxy
+     */
+    protected function getServiceProxy()
+    {
+        /** @noinspection PhpIncompatibleReturnTypeInspection */
+        return $this->getServiceLocator()->get(ServiceProxy::SERVICE_ID);
+    }
+
+    /**
+     * @return QtiResultsService
+     */
+    protected function getQtiResultsService(): QtiResultsService
+    {
+        /** @noinspection PhpIncompatibleReturnTypeInspection */
+        return $this->getServiceLocator()->get(QtiResultsService::SERVICE_ID);
+    }
+
+    /**
+     * @return ResultsService
+     */
+    protected function getResultsService(): ResultsService
+    {
+        /** @noinspection PhpIncompatibleReturnTypeInspection */
+        return $this->getServiceLocator()->get(ResultsService::SERVICE_ID);
+    }
+}


### PR DESCRIPTION
Related to ticket:
https://oat-sa.atlassian.net/browse/RE-46

How to run:
`php index.php 'oat\taoOutcomeUi\scripts\task\ExportDeliveryClassXmlResults' -u http://www.tao.lu/Ontologies/TAODelivery.rdf#AssembledDelivery -p NSA_results`

1 memory leak found in the object \ZipArchive. It was fixed by just recreating the object every 1000 iterations (and of course saving the progress in advance). Now memory usage is completely flat, i.e. even with billions of results in a delivery memory consumption is constantly 2.5 megabytes.