### PR TITLE
RE-228: fix: show trace variables of answer on result page

### DIFF
--- a/model/ResultsService.php
+++ b/model/ResultsService.php
@@ -605,7 +605,7 @@ class ResultsService extends OntologyClassService
                 $variable = $itemVariable->variable;
                 $itemCallId = $itemVariable->callIdItem;
                 if ($variable->getIdentifier() == 'numAttempts') {
-                    $variablesByItem[$time] = $this->getItemInfos($itemCallId, [[$itemVariable]]);
+                    $variablesByItem[$time] = array_merge($variablesByItem[$time], $this->getItemInfos($itemCallId, [[$itemVariable]]));
                     $variablesByItem[$time]['attempt'] = $variable->getValue();
                 }
                 $variableDescription = [


### PR DESCRIPTION
Related task: https://oat-sa.atlassian.net/browse/RE-228

**Steps to reproduce:**
- activate the plugin `itemTraceVariables` (in file `config/taoTests/test_runner_plugin_registry.conf.php`, search for the plugin and enable it by setting the active property to true)
- take a test, and check the action `storeTraceData` is sent to the server, with some variables in it, like `ITEM_START_TIME_CLIENT` (check the Network panel in the browser's console)
- open the TAO back office, and go to the result page, 

**Expected result:**
There `Traces` with trace variables in result page