### PR TITLE
fix: showing right selected answrs in result view

### DIFF
--- a/model/ResultsService.php
+++ b/model/ResultsService.php
@@ -601,6 +601,7 @@ class ResultsService extends OntologyClassService
         $attempts = $this->splitByItemAndAttempt($itemVariables, $filter);
         $variablesByItem = [];
         foreach ($attempts as $time => $variables) {
+            $variablesByItem[$time] = [];
             foreach ($variables as $itemVariable) {
                 $variable = $itemVariable->variable;
                 $itemCallId = $itemVariable->callIdItem;


### PR DESCRIPTION
Related to ticket: https://oat-sa.atlassian.net/browse/RE-228

Bug: selected value don't show in result view

Fix: this issue related to not initialized array value `$variablesByItem[$time]`. Not reproduced on all cases but happens sometimes.