### PR TITLE
Feature/TR-765/load test taker response in audio PCI

### DIFF
--- a/helper/ResponseVariableFormatter.php
+++ b/helper/ResponseVariableFormatter.php
@@ -109,22 +109,22 @@ class ResponseVariableFormatter
             case 'multiple':
                     $list = [];
 
-                    if(!empty($value) 
+                    if(!empty($value)
                         && preg_match('/^\s*[\[|<](.*)[\]>]\s*$/', $value, $content)
                     ) {
                      $matches = explode(';', $content[1]);
                         foreach ($matches as $valueString) {
-                            if (empty(trim($valueString))) {	
+                            if (empty(trim($valueString))) {
                                 continue;
                             }
-                            
+
                             try {
                                 $list[] = self::formatStringValue($var->getBaseType(), trim($valueString, " '"));
                             } catch (\common_exception_NotImplemented $e) {
                                 // simply ignore unsupported data/type
                             }
                         }
-                    }                    
+                    }
 
                     $formatted = ['list' => [$var->getBaseType() => $list]];
                 break;
@@ -157,13 +157,20 @@ class ResponseVariableFormatter
 
             $itemResults = [];
             foreach ($itemResult['taoResultServer_models_classes_ResponseVariable'] as $var) {
-                $responseVariable = $var['var'];
                 /**
                  * @var $responseVariable \taoResultServer_models_classes_ResponseVariable
                  */
-                $itemResults[$responseVariable->getIdentifier()] = [
-                    'response' => self::formatVariableToPci($responseVariable)
-                ];
+                $responseVariable = $var['var'];
+
+                if ($responseVariable->getBaseType() === 'file') {
+                    $itemResults[$responseVariable->getIdentifier()] = [
+                        'response' => ['base' => ['file' => ['uri' => $var['uri']]]]
+                    ];
+                } else {
+                    $itemResults[$responseVariable->getIdentifier()] = [
+                        'response' => self::formatVariableToPci($responseVariable)
+                    ];
+                }
             }
 
             $formatted[$itemUri][$itemResult['attempt']] = $itemResults;

--- a/views/js/controller/viewResult.js
+++ b/views/js/controller/viewResult.js
@@ -23,11 +23,129 @@ define([
     'jquery',
     'i18n',
     'util/url',
+    'core/logger',
     'layout/section',
     'taoItems/previewer/factory',
     'jquery.fileDownload'
-], function (module, $,  __,  urlHelper, section, previewerFactory) {
+], function (
+    module,
+    $,
+    __,
+    urlHelper,
+    loggerFactory,
+    section,
+    previewerFactory
+) {
     'use strict';
+
+    const logger = loggerFactory('taoOutcomeUi/viewResults');
+    const downloadUrl = urlHelper.route('getFile', 'Results', 'taoOutcomeUi');
+
+    /**
+     * Removes a cookie added by the download request
+     * @param {String} path
+     */
+    function clearDownloadCookie(path) {
+        document.cookie = `fileDownload=; expires=${(new Date(1000)).toUTCString()}; path=${path}`;
+    };
+
+    /**
+     * Builds an error object based on the supplied AJAX context
+     * @param {String} message
+     * @param {Object} response
+     * @param {XMLHttpRequest} xhr
+     * @returns {Error}
+     */
+    function getAjaxError(message, response, xhr) {
+        const err = new Error(message);
+        err.response = response;
+        err.code = xhr.status;
+        err.sent = xhr.readyState > 0;
+        return err;
+    }
+
+    /**
+     * Requests an endpoint for a data file
+     * @param {Object} params
+     * @returns {Promise}
+     */
+    function requestData(params) {
+        return new Promise((resolve, reject) => {
+            $.ajax(params)
+                .done((response, status, xhr) => {
+                    if (xhr.status === 204 || status === 'nocontent') {
+                        return resolve();
+                    }
+                    if (xhr.status === 200) {
+                        const contentType = xhr.getResponseHeader('Content-Type') || '';
+                        return resolve({
+                            data: response,
+                            mime: contentType.toLocaleLowerCase().replace('content-type:', '').trim()
+                        });
+                    }
+                    reject(getAjaxError(__('The server has sent an empty response'), response, xhr));
+                })
+                .fail((xhr, textStatus, errorThrown) => {
+                    reject(getAjaxError(errorThrown || __('An error occurred!'), xhr.responseText, xhr));
+                });
+        });
+    }
+
+    /**
+     * Requests a file content given the URIs
+     * @param {String} variableUri - The URI of a variable
+     * @param {String} deliveryUri - The URI of a delivery
+     * @returns {Promise}
+     */
+    function requestFileContent(variableUri, deliveryUri) {
+        return requestData({
+            url: downloadUrl,
+            method: 'POST',
+            data: { variableUri, deliveryUri },
+            dataType: 'text'
+        })
+            .catch(e => logger.error(e))
+            .then(data => {
+                clearDownloadCookie('/');
+                clearDownloadCookie('/taoOutcomeUi/Results');
+                return data;
+            });
+    }
+
+    /**
+     * Makes sure the response contains the file data if it is a file record
+     * @param {Object} response
+     * @param {String} deliveryUri
+     * @returns {Promise}
+     */
+    function refineFileResponse(response, deliveryUri) {
+        const { file } = response && response.base || {};
+        if (file && file.uri && !file.data) {
+            return requestFileContent(file.uri, deliveryUri)
+                .then(data => {
+                    response.base.file = data;
+                });
+        }
+        return Promise.resolve();
+    }
+
+    /**
+     * Makes sure the item state contains the file data in the response if it is a file record
+     * @param {Object} state
+     * @param {String} deliveryUri
+     * @returns {Promise}
+     */
+    function refineItemState(state, deliveryUri) {
+        if (!state) {
+            return Promise.resolve(state);
+        }
+
+        const filePromises = Object.keys(state).map(identifier => {
+            const { response } = state[identifier];
+            return refineFileResponse(response, deliveryUri);
+        });
+        return Promise.all(filePromises).then(() => state);
+    }
 
     /**
      * @exports taoOutcomeUi/controller/viewResult
@@ -39,10 +157,12 @@ define([
          */
         start(){
             const conf = module.config();
+            const deliveryUri = conf.classUri;
             const $container = $('#view-result');
             const $resultFilterField = $('.result-filter', $container);
             const $classFilterField = $('[name="class-filter"]', $container);
             let classFilter = JSON.parse(conf.filterTypes) || [];
+
             //set up filter field
             $resultFilterField.select2({
                 minimumResultsForSearch : -1
@@ -72,25 +192,28 @@ define([
 
             //bind the download buttons
             $('.download', $container).on('click', function() {
-                var variableUri = $(this).val();
-                $.fileDownload(urlHelper.route('getFile', 'Results', 'taoOutcomeUi'), {
+                const variableUri = $(this).val();
+                $.fileDownload(downloadUrl, {
                     preparingMessageHtml: __("We are preparing your report, please wait..."),
                     failMessageHtml: __("There was a problem generating your report, please try again."),
                     httpMethod: "POST",
                     //This gives the current selection of filters (facet based query) and the list of columns selected from the client (the list of columns is not kept on the server side class.taoTable.php
-                    data: {'variableUri': variableUri, 'deliveryUri':conf.classUri}
+                    data: { variableUri, deliveryUri }
                 });
             });
 
             $('.preview', $container).on('click', function(e) {
-                const $this = $(this);
-                const deliveryId = $this.data('deliveryId');
-                const resultId = $this.data('resultId');
-                const itemDefinition = $this.data('definition');
-                let uri = $this.data('uri');
-                const type = $this.data('type');
-                const state = $this.data('state');
+                const $btn = $(this);
+                const deliveryId = $btn.data('deliveryId');
+                const resultId = $btn.data('resultId');
+                const itemDefinition = $btn.data('definition');
+                let uri = $btn.data('uri');
+                const type = $btn.data('type');
                 e.preventDefault();
+                if ($btn.prop('disabled')) {
+                    return;
+                }
+                $btn.prop('disabled', true).addClass('disabled');
 
                 if (deliveryId && resultId && itemDefinition) {
                     uri = {
@@ -101,10 +224,16 @@ define([
                     };
                 }
 
-                previewerFactory(type, uri, state, {
-                    view: 'reviewRenderer',
-                    fullPage: true
-                });
+                Promise.resolve($btn.data('state'))
+                    .then(state => refineItemState(state, deliveryUri))
+                    .then(state => {
+                        $btn.removeProp('disabled').removeClass('disabled');
+                        previewerFactory(type, uri, state, {
+                            view: 'reviewRenderer',
+                            fullPage: true
+                        });
+                    })
+                    .catch(e => logger.error(e));
             });
 
         }

--- a/views/js/controller/viewResult.js
+++ b/views/js/controller/viewResult.js
@@ -183,15 +183,7 @@ define([
                 }
 
                 Promise.resolve($btn.data('state'))
-                    .then(state => {
-                        console.log(JSON.stringify(state));
-                        return state;
-                    })
                     .then(state => refineItemState(state, deliveryUri))
-                    .then(state => {
-                        console.log(JSON.stringify(state));
-                        return state;
-                    })
                     .then(state => {
                         $btn.removeProp('disabled').removeClass('disabled');
                         previewerFactory(type, uri, state, {

--- a/views/js/controller/viewResult.js
+++ b/views/js/controller/viewResult.js
@@ -75,7 +75,13 @@ define([
         const { file } = response && response.base || {};
         if (file && file.uri && !file.data) {
             return requestFileContent(file.uri, deliveryUri)
-                .then(data => response.base.file = data)
+                .then(fileData => {
+                    if (fileData && fileData.data) {
+                        response.base.file = fileData;
+                    } else {
+                        response.base = null;
+                    }
+                })
                 .catch(e => logger.error(e));
         }
         return Promise.resolve();
@@ -177,7 +183,15 @@ define([
                 }
 
                 Promise.resolve($btn.data('state'))
+                    .then(state => {
+                        console.log(JSON.stringify(state));
+                        return state;
+                    })
                     .then(state => refineItemState(state, deliveryUri))
+                    .then(state => {
+                        console.log(JSON.stringify(state));
+                        return state;
+                    })
                     .then(state => {
                         $btn.removeProp('disabled').removeClass('disabled');
                         previewerFactory(type, uri, state, {

--- a/views/js/controller/viewResult.js
+++ b/views/js/controller/viewResult.js
@@ -56,7 +56,6 @@ define([
             method: 'POST',
             data: { variableUri, deliveryUri }
         })
-            .catch(e => logger.error(e))
             .then(response => {
                 // The response may contain more than the expected data,
                 // like the success status, which is not relevant here.
@@ -76,7 +75,8 @@ define([
         const { file } = response && response.base || {};
         if (file && file.uri && !file.data) {
             return requestFileContent(file.uri, deliveryUri)
-                .then(data => response.base.file = data);
+                .then(data => response.base.file = data)
+                .catch(e => logger.error(e));
         }
         return Promise.resolve();
     }


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TR-765

Requires: 
 - [x] https://github.com/oat-sa/tao-item-runner-qti-fe/pull/159
 - [x] https://github.com/oat-sa/extension-tao-itemqti/pull/1662
 - [x] https://github.com/oat-sa/extension-tao-itemqti-pci/pull/221

Update the Results page to allow loading the file content related to QTI file variables. This mainly aims the `audioRecording` PCI, but technically it could apply to any interaction working with a file variable.

Basically, here is what changed:
- the Results controller gets an additional endpoint to serve the file content from a QTI variable
- the variable formatter is supplying the variable URI  instead of replacing the file variable by an empty value
- the `viewResults` client controller scrutinizes the response state of the item, searching for partial file response, then it loads the file content thanks to the supplied variable URI and updates the state before opening up the review component

How to test:
- apply the companion PRs
- take a test containing an audio PCI (you may use the one linked in the ticket, caution the first copy I made contained an outdated version of the PCI, be sure to take the updated one, labelled `test_audio_recording_v12.zip`)
- login in the backoffice and go to the results page
- review the item containing the audio PCI, it should allow replaying the record

Edit: The following issue has been fixed.
**Note:** ~~for the time being, a regression exists because of RE-228. This prevents the state to be available for the item review. While the fix is not there, you can workaround this issue by applying this patch:~~
- ~~open `taoOutcomeUi/model/ResultsService.php`~~
- ~~replace the line 608 by `$variablesByItem[$time] = array_merge($variablesByItem[$time]??[], $this->getItemInfos($itemCallId, [[$itemVariable]]));`~~


**Note 2:** for the time being, the audioRecording PCI allows to record in the review mode as well. This will be addressed by MS-988 and is not part of this PR.