### PR TITLE
feat: Remove csv export data preview

### DIFF
--- a/views/js/controller/resultTable.js
+++ b/views/js/controller/resultTable.js
@@ -239,7 +239,6 @@ define([
                 taskQueue: taskQueue,
                 taskCreationUrl: urlUtil.route('export', 'ResultTable', 'taoOutcomeUi'),
                 taskCreationData: function getTaskRequestData() {
-                    filterChanged();
                     return {
                         filter: filter,
                         columns: JSON.stringify(columns),


### PR DESCRIPTION
How to test: Go to the "Results/Export Table" page and press "Export CSV file" button. Export data preview should not appear, but downloading of the export file should start.