### PR TITLE
Bug/tr 1909/incorect answers represented in review

### DIFF
--- a/controller/Results.php
+++ b/controller/Results.php
@@ -553,11 +553,13 @@ class Results extends \tao_actions_CommonModule
 
     /**
      * Regroup item variables by attempt
+     *
      * @param array $variables
      * @param array $filterTypes
      * @return array
+     * @throws common_Exception
      */
-    protected function formatItemVariables($variables, $filterTypes)
+    protected function formatItemVariables(array $variables, array $filterTypes): array
     {
         $displayedVariables = $this->getResultsService()->filterStructuredVariables($variables, $filterTypes);
         $responses = ResponseVariableFormatter::formatStructuredVariablesToItemState($variables);

--- a/controller/Results.php
+++ b/controller/Results.php
@@ -23,17 +23,20 @@
 namespace oat\taoOutcomeUi\controller;
 
 use common_Exception;
+use common_exception_BadRequest;
 use common_exception_NotFound;
-use \Exception;
-use \common_exception_BadRequest;
+use Exception;
 use oat\generis\model\GenerisRdf;
 use oat\generis\model\OntologyAwareTrait;
 use oat\generis\model\OntologyRdfs;
 use oat\oatbox\event\EventManager;
+use oat\tao\helpers\UserHelper;
+use oat\tao\model\datatable\implementation\DatatableRequest;
 use oat\tao\model\plugins\PluginModule;
 use oat\tao\model\taskQueue\TaskLogActionTrait;
 use oat\taoDelivery\model\execution\DeliveryExecutionInterface;
 use oat\taoDelivery\model\execution\ServiceProxy;
+use oat\taoDeliveryRdf\model\DeliveryAssemblyService;
 use oat\taoOutcomeUi\helper\ResponseVariableFormatter;
 use oat\taoOutcomeUi\model\event\ResultsListPluginEvent;
 use oat\taoOutcomeUi\model\export\DeliveryCsvResultsExporterFactory;
@@ -41,19 +44,16 @@ use oat\taoOutcomeUi\model\export\DeliveryResultsExporterFactoryInterface;
 use oat\taoOutcomeUi\model\export\DeliverySqlResultsExporterFactory;
 use oat\taoOutcomeUi\model\export\ResultsExporter;
 use oat\taoOutcomeUi\model\plugins\ResultsPluginService;
+use oat\taoOutcomeUi\model\ResultsService;
 use oat\taoOutcomeUi\model\search\ResultsWatcher;
 use oat\taoOutcomeUi\model\table\ResultsMonitoringDatatable;
 use oat\taoOutcomeUi\model\Wrapper\ResultServiceWrapper;
 use oat\taoResultServer\models\classes\NoResultStorage;
 use oat\taoResultServer\models\classes\NoResultStorageException;
 use oat\taoResultServer\models\classes\QtiResultsService;
-use oat\taoResultServer\models\Formatter\ItemResponseCollectionNormalizer;
-use \tao_helpers_Uri;
-use oat\taoOutcomeUi\model\ResultsService;
-use oat\taoDeliveryRdf\model\DeliveryAssemblyService;
 use oat\taoResultServer\models\classes\ResultServerService;
-use oat\tao\helpers\UserHelper;
-use oat\tao\model\datatable\implementation\DatatableRequest;
+use oat\taoResultServer\models\Formatter\ItemResponseCollectionNormalizer;
+use tao_helpers_Uri;
 
 /**
  * Results Controller provide actions performed from url resolution
@@ -563,14 +563,11 @@ class Results extends \tao_actions_CommonModule
         $responses = ResponseVariableFormatter::formatStructuredVariablesToItemState($variables);
         $excludedVariables = array_flip(['numAttempts', 'duration']);
 
-        foreach ($displayedVariables as &$item) {
-            if (!isset($item['uri'])) {
-                continue;
-            }
-            $itemUri = $item['uri'];
-            $state = isset($responses[$itemUri][$item['attempt']])
-                ? array_diff_key($responses[$itemUri][$item['attempt']], $excludedVariables)
+        foreach ($displayedVariables as $itemKey => &$item) {
+            $state = isset($responses[$itemKey][$item['attempt']])
+                ? array_diff_key($responses[$itemKey][$item['attempt']], $excludedVariables)
                 : [];
+
             $item['state'] = !empty($state) ? json_encode($state) : '{}';
         }
 

--- a/helper/ResponseVariableFormatter.php
+++ b/helper/ResponseVariableFormatter.php
@@ -142,8 +142,10 @@ class ResponseVariableFormatter
      * @return array
      * @throws \common_Exception
      */
-    public static function formatStructuredVariablesToItemState($testResultVariables, $itemFilter = [])
-    {
+    public static function formatStructuredVariablesToItemState(
+        array $testResultVariables,
+        array $itemFilter = []
+    ): array {
         $formatted = [];
         foreach ($testResultVariables as $itemKey => $itemResult) {
             if (!isset($itemResult['uri'])) {
@@ -174,6 +176,7 @@ class ResponseVariableFormatter
 
             $formatted[$itemKey][$itemResult['attempt']] = $itemResults;
         }
+
         return $formatted;
     }
 }

--- a/helper/ResponseVariableFormatter.php
+++ b/helper/ResponseVariableFormatter.php
@@ -21,7 +21,7 @@
 
 namespace oat\taoOutcomeUi\helper;
 
-use \taoResultServer_models_classes_ResponseVariable as ResponseVariable;
+use taoResultServer_models_classes_ResponseVariable as ResponseVariable;
 
 /**
  * The ResponseVariableFormatter enables you to format the output of the ResultsService into an associative compatible with the client code
@@ -145,13 +145,12 @@ class ResponseVariableFormatter
     public static function formatStructuredVariablesToItemState($testResultVariables, $itemFilter = [])
     {
         $formatted = [];
-        foreach ($testResultVariables as $itemResult) {
+        foreach ($testResultVariables as $itemKey => $itemResult) {
             if (!isset($itemResult['uri'])) {
                 continue;
             }
 
-            $itemUri = $itemResult['uri'];
-            if (!empty($itemFilter) && !in_array($itemUri, $itemFilter)) {
+            if (!empty($itemFilter) && !in_array($itemResult['uri'], $itemFilter)) {
                 continue;
             }
 
@@ -173,7 +172,7 @@ class ResponseVariableFormatter
                 }
             }
 
-            $formatted[$itemUri][$itemResult['attempt']] = $itemResults;
+            $formatted[$itemKey][$itemResult['attempt']] = $itemResults;
         }
         return $formatted;
     }


### PR DESCRIPTION
# [TR-1909](https://oat-sa.atlassian.net/browse/TR-1909)
## Summary
about duplicated displaying of responses for the same items in result preview
## How to reproduce
* execute delivery of test with duplicated items ([exampl](https://github.com/oat-sa/extension-tao-outcomeui/files/7603435/qa_check_1637742584.zip))
* overview execute on results page
* try to open review of response item (response of the last duplicated item will be provided)

https://user-images.githubusercontent.com/37804293/143454583-59aaa191-7e55-419a-ae00-244607b85924.mp4

## How to test fix
* install extension with pr branch 
* execute steps from `How to reproduce`
* right response items will be displayed

https://user-images.githubusercontent.com/37804293/143454611-fff3b55c-f8f2-40d3-90a1-6e8c93677aee.mp4
