### PR TITLE
feat: allow embedded files to be retrieved in the response

### DIFF
--- a/helper/ResponseVariableFormatter.php
+++ b/helper/ResponseVariableFormatter.php
@@ -146,6 +146,7 @@ class ResponseVariableFormatter
         array $testResultVariables,
         array $itemFilter = []
     ): array {
+
         $formatted = [];
         foreach ($testResultVariables as $itemKey => $itemResult) {
             if (!isset($itemResult['uri'])) {
@@ -158,14 +159,12 @@ class ResponseVariableFormatter
 
             $itemResults = [];
             foreach ($itemResult['taoResultServer_models_classes_ResponseVariable'] as $var) {
-                /**
-                 * @var $responseVariable \taoResultServer_models_classes_ResponseVariable
-                 */
+                /** @var $responseVariable ResponseVariable */
                 $responseVariable = $var['var'];
 
                 if ($responseVariable->getBaseType() === 'file') {
                     $itemResults[$responseVariable->getIdentifier()] = [
-                        'response' => ['base' => ['file' => ['uri' => $var['uri']]]]
+                        'response' => ['base' => ['file' => self::formatVariableFile($responseVariable)]]
                     ];
                 } else {
                     $itemResults[$responseVariable->getIdentifier()] = [
@@ -178,5 +177,14 @@ class ResponseVariableFormatter
         }
 
         return $formatted;
+    }
+
+    private static function formatVariableFile(ResponseVariable $responseVariable): array
+    {
+        $file = Datatypes::decodeFile($responseVariable->getCandidateResponse());
+
+        $file['data'] = base64_encode($file['data']);
+
+        return $file;
     }
 }


### PR DESCRIPTION
## Ticket
https://oat-sa.atlassian.net/browse/TR-2972

## Summary
Responses with embedded files are not being rendered properly on review mode.

## How to test
1. Launch a test that has at least one interaction that stores a file (for example, Audio recording or File Upload)
[audio_recording_1640100368.zip](https://github.com/oat-sa/extension-lti-test-review/files/7756949/audio_recording_1640100368.zip)
2. Complete the test
3. Launch the test again in Review Mode (https://oat-sa.atlassian.net/l/c/Y26yhkAs)
4. Navigate to the item with respective interaction
5. The file should load without issues:
Audio recording interaction:
![image](https://user-images.githubusercontent.com/1084316/146972286-d5277b72-ff76-4ea8-be74-53e47629987e.png)

File upload interaction:
![image](https://user-images.githubusercontent.com/1084316/146972514-27fa4a0a-ea29-415b-bd16-dcc98e9aa027.png)


## Sandbox environment
Terre: https://delivery.test-tr2972.playground.kitchen.it.taocloud.org
Devkit: https://devkit-pg-cf87772fc920e62.cicd.gcp-eu.taocloud.org