### PR TITLE
AUT-1483 - solar ignite fix decoding of stored files to prevent warnings

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -70,5 +70,11 @@
         "psr-4" : {
             "oat\\taoOutcomeUi\\" : ""
         }
+    },
+    "config": {
+        "allow-plugins": {
+            "oat-sa/oatbox-extension-installer": true,
+            "oat-sa/composer-npm-bridge": true
+        }
     }
 }

--- a/helper/Datatypes.php
+++ b/helper/Datatypes.php
@@ -15,7 +15,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2014 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ * Copyright (c) 2014-2022 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
  *
  */
 
@@ -30,7 +30,7 @@ namespace oat\taoOutcomeUi\helper;
  */
 class Datatypes
 {
-    
+
     /**
      * Decode a binary string representing a file into an array.
      *
@@ -53,21 +53,38 @@ class Datatypes
      */
     public static function decodeFile($binary)
     {
-        
+
         $returnValue = ['name' => '', 'mime' => '', 'data' => ''];
-        
+
         if (empty($binary) === false) {
             $filenameLen = current(unpack('S', substr($binary, 0, 2)));
+
+            //validate case when unpacked filename length more or equal entire provided string
+            // what mean that provided string definitely in incorrect format
+            if ($filenameLen >= strlen($binary)) {
+                return $returnValue;
+            }
+
             if ($filenameLen > 0) {
                 $returnValue['name'] = substr($binary, 2, $filenameLen);
             }
-            
-            $mimetypeLen = current(unpack('S', substr($binary, 2 + $filenameLen, 2)));
+
+            $packedMimeTypeLen = substr($binary, 2 + $filenameLen, 2);
+            if ($packedMimeTypeLen === false) {
+                return $returnValue;
+            }
+
+            $unpackedMimeTypeLen = unpack('S', $packedMimeTypeLen);
+            if ($unpackedMimeTypeLen === false) {
+                return $returnValue;
+            }
+
+            $mimetypeLen = current($unpackedMimeTypeLen);
             $returnValue['mime'] = substr($binary, 4 + $filenameLen, $mimetypeLen);
-            
+
             $returnValue['data'] = substr($binary, 4 + $filenameLen + $mimetypeLen);
         }
-        
+
         return $returnValue;
     }
 }

--- a/helper/Datatypes.php
+++ b/helper/Datatypes.php
@@ -21,9 +21,6 @@
 
 namespace oat\taoOutcomeUi\helper;
 
-use oat\oatbox\filesystem\utils\FlyWrapperTrait;
-use oat\taoDeliveryRdf\view\form\WizardForm;
-
 /**
  * A class focusing on providing utility methods for the various result datatypes
  * that might be sent/stored to/by a result server.
@@ -58,38 +55,40 @@ class Datatypes
     {
         $returnValue = ['name' => '', 'mime' => '', 'data' => ''];
 
-        if (empty($binary) === false) {
-            $binaryStream = fopen('php://memory', 'r+');
-            fwrite($binaryStream, $binary);
-            rewind($binaryStream);
-
-            $binaryLength = strlen($binary);
-            $filenameLen = current(unpack('S', fread($binaryStream, 2)));
-
-            //validate case when unpacked filename length more or equal entire provided string
-            // what mean that provided string definitely in incorrect format
-            if ($filenameLen >= $binaryLength) {
-                return $returnValue;
-            }
-
-            if ($filenameLen > 0) {
-                $returnValue['name'] = fread($binaryStream, $filenameLen);
-            }
-
-            $packedMimeTypeLen = fread($binaryStream, $filenameLen);
-            if ($packedMimeTypeLen === false) {
-                return $returnValue;
-            }
-
-            $unpackedMimeTypeLen = unpack('S', $packedMimeTypeLen);
-            if ($unpackedMimeTypeLen === false) {
-                return $returnValue;
-            }
-
-            $mimetypeLen = current($unpackedMimeTypeLen);
-            $returnValue['mime'] = fread($binaryStream, $mimetypeLen);
-            $returnValue['data'] = stream_get_contents($binaryStream);
+        if (empty($binary)) {
+            return $returnValue;
         }
+
+        $binaryStream = fopen('php://memory', 'r+');
+        fwrite($binaryStream, $binary);
+        rewind($binaryStream);
+
+        $binaryLength = strlen($binary);
+        $filenameLen = current(unpack('S', fread($binaryStream, 2)));
+
+        //validate case when unpacked filename length more or equal entire provided string
+        // what mean that provided string definitely in incorrect format
+        if ($filenameLen >= $binaryLength) {
+            return $returnValue;
+        }
+
+        if ($filenameLen > 0) {
+            $returnValue['name'] = fread($binaryStream, $filenameLen);
+        }
+
+        $packedMimeTypeLen = fread($binaryStream, $filenameLen);
+        if ($packedMimeTypeLen === false) {
+            return $returnValue;
+        }
+
+        $unpackedMimeTypeLen = unpack('S', $packedMimeTypeLen);
+        if ($unpackedMimeTypeLen === false) {
+            return $returnValue;
+        }
+
+        $mimetypeLen = current($unpackedMimeTypeLen);
+        $returnValue['mime'] = fread($binaryStream, $mimetypeLen);
+        $returnValue['data'] = stream_get_contents($binaryStream);
 
         return $returnValue;
     }

--- a/helper/Datatypes.php
+++ b/helper/Datatypes.php
@@ -21,6 +21,9 @@
 
 namespace oat\taoOutcomeUi\helper;
 
+use oat\oatbox\filesystem\utils\FlyWrapperTrait;
+use oat\taoDeliveryRdf\view\form\WizardForm;
+
 /**
  * A class focusing on providing utility methods for the various result datatypes
  * that might be sent/stored to/by a result server.
@@ -53,23 +56,27 @@ class Datatypes
      */
     public static function decodeFile($binary)
     {
-
         $returnValue = ['name' => '', 'mime' => '', 'data' => ''];
 
         if (empty($binary) === false) {
-            $filenameLen = current(unpack('S', substr($binary, 0, 2)));
+            $binaryStream = fopen('php://memory', 'r+');
+            fwrite($binaryStream, $binary);
+            rewind($binaryStream);
+
+            $binaryLength = strlen($binary);
+            $filenameLen = current(unpack('S', fread($binaryStream, 2)));
 
             //validate case when unpacked filename length more or equal entire provided string
             // what mean that provided string definitely in incorrect format
-            if ($filenameLen >= strlen($binary)) {
+            if ($filenameLen >= $binaryLength) {
                 return $returnValue;
             }
 
             if ($filenameLen > 0) {
-                $returnValue['name'] = substr($binary, 2, $filenameLen);
+                $returnValue['name'] = fread($binaryStream, $filenameLen);
             }
 
-            $packedMimeTypeLen = substr($binary, 2 + $filenameLen, 2);
+            $packedMimeTypeLen = fread($binaryStream, $filenameLen);
             if ($packedMimeTypeLen === false) {
                 return $returnValue;
             }
@@ -80,9 +87,8 @@ class Datatypes
             }
 
             $mimetypeLen = current($unpackedMimeTypeLen);
-            $returnValue['mime'] = substr($binary, 4 + $filenameLen, $mimetypeLen);
-
-            $returnValue['data'] = substr($binary, 4 + $filenameLen + $mimetypeLen);
+            $returnValue['mime'] = fread($binaryStream, $mimetypeLen);
+            $returnValue['data'] = stream_get_contents($binaryStream);
         }
 
         return $returnValue;


### PR DESCRIPTION
# [AUT-1483](https://oat-sa.atlassian.net/browse/AUT-1483)

## Summary
Result page receive unexpected warning at file download and in top of page

## How to test 
* update backoffice by branch
* configure launching deliver on solar with lti in terre
    *  [Conflence doc](https://oat-sa.atlassian.net/wiki/spaces/~575513335/pages/1667204040/LTI+1.3+-+Deliver+Launch)
    * [Readme from `extension-tao-deliver-connect`](https://github.com/oat-sa/extension-tao-deliver-connect/blob/master/README.md)
* execute delivery with file upload interaction
* Result page for execution statements not provided for execution with files stored in incorrect format 
```
Warning: unpack(): Type S: not enough input, need 2, have 0 in /tao/code/taoOutcomeUi/helper/Datatypes.php on line 65 Warning: current() expects parameter 1 to be array, bool given in /tao/code/taoOutcomeUi/helper/Datatypes.php on line 65
```

---
Example of .env
```
FEATURE_FLAG_LTI1P3=true
DELIVERTENANT_COUNT=1
DELIVERTENANT_0_ID=1
DELIVERTENANT_0_LABEL="Customer 1 - Deliver - LTI 1.3 - .env"
DELIVERTENANT_0_CUSTOMER_ID=1
DELIVERTENANT_0_ROOT_URL=http://deliver.docker.localhost/api/v1/
DELIVERTENANT_0_OAUTH_CREDENTIALS_COUNT=1
DELIVERTENANT_0_OAUTH_CREDENTIALS_0_KEY=bbb1
DELIVERTENANT_0_OAUTH_CREDENTIALS_0_SECRET=bbb1
DELIVERTENANT_0_OAUTH_CREDENTIALS_0_ROLES_0=Learner
DELIVERTENANT_0_OAUTH_CREDENTIALS_0_ROLES_1=ContentDeveloper
DELIVERTENANT_0_OAUTH_CREDENTIALS_0_ROLES_COUNT=2
DELIVERTENANT_0_LTI_CREDENTIALS_0_KEY=aaa1
DELIVERTENANT_0_LTI_CREDENTIALS_0_SECRET=aaa1
DELIVERTENANT_0_LTI_CREDENTIALS_0_ROLES_COUNT=2
DELIVERTENANT_0_LTI_CREDENTIALS_0_ROLES_0=Learner
DELIVERTENANT_0_LTI_CREDENTIALS_0_ROLES_1=ContentDeveloper
DELIVERTENANT_0_LTI_CREDENTIALS_COUNT=1
```
## TAE
https://oat-sa.atlassian.net/browse/AUT-1483?focusedCommentId=181364