### PR TITLE
[FIX] included the option all on submittedVersion parameter #420

### DIFF
--- a/scripts/task/ExportDeliveryResults.php
+++ b/scripts/task/ExportDeliveryResults.php
@@ -222,7 +222,11 @@ class ExportDeliveryResults implements Action, ServiceLocatorAwareInterface, Wor
                         break;
 
                     case '--submittedVersion':
-                        if (!in_array($value, [ResultsService::VARIABLES_FILTER_ALL, ResultsService::VARIABLES_FILTER_FIRST_SUBMITTED, ResultsService::VARIABLES_FILTER_LAST_SUBMITTED])) {
+                       if (!in_array($value, [
+                                ResultsService::VARIABLES_FILTER_ALL,
+                                ResultsService::VARIABLES_FILTER_FIRST_SUBMITTED,
+                                ResultsService::VARIABLES_FILTER_LAST_SUBMITTED
+                            ])) {
                             throw new \InvalidArgumentException('Invalid submitted version of variables "' . $value . '". Valid options: ' . implode(', ', [ResultsService::VARIABLES_FILTER_FIRST_SUBMITTED, ResultsService::VARIABLES_FILTER_LAST_SUBMITTED]));
                         }
 

--- a/scripts/task/ExportDeliveryResults.php
+++ b/scripts/task/ExportDeliveryResults.php
@@ -222,7 +222,7 @@ class ExportDeliveryResults implements Action, ServiceLocatorAwareInterface, Wor
                         break;
 
                     case '--submittedVersion':
-                        if (!in_array($value, [ResultsService::VARIABLES_FILTER_FIRST_SUBMITTED, ResultsService::VARIABLES_FILTER_LAST_SUBMITTED])) {
+                        if (!in_array($value, [ResultsService::VARIABLES_FILTER_ALL, ResultsService::VARIABLES_FILTER_FIRST_SUBMITTED, ResultsService::VARIABLES_FILTER_LAST_SUBMITTED])) {
                             throw new \InvalidArgumentException('Invalid submitted version of variables "' . $value . '". Valid options: ' . implode(', ', [ResultsService::VARIABLES_FILTER_FIRST_SUBMITTED, ResultsService::VARIABLES_FILTER_LAST_SUBMITTED]));
                         }
 


### PR DESCRIPTION
Included the option all on submittedVersion parameter to be able to export all submitted versions at once.

## how to test
1. run the command:
```shell script
php index.php 'oat\taoOutcomeUi\scripts\task\ExportDeliveryResults' 'https://nmpp.nsa.etestavimas.lt#Delivery_2022spring_N2G81LTSL_1645454301' --columns=all --submittedVersion=all
```
2. check the output on `/path/to/tao/data/taskQueueStorage`