### PR TITLE
fix: export class with all submitted responses

### DIFF
--- a/model/export/MultipleDeliveriesResultsExporter.php
+++ b/model/export/MultipleDeliveriesResultsExporter.php
@@ -272,6 +272,7 @@ class MultipleDeliveriesResultsExporter implements ResultsExporterInterface
                 $delivery,
                 $this->resultsService
             )->setServiceLocator($this->getServiceLocator())
+             ->setVariableToExport($this->getVariableToExport())
              ->export($destination);
         }
 


### PR DESCRIPTION
The `\oat\taoOutcomeUi\scripts\task\ExportDeliveryResults` cannot export the whole class with all submitted responses

Steps for testing:
1. Create some deliveries and pass them with a few attempts for some items
2. Put those deliveries to one class, or use the root class
3. Run the next command for exporting
`sudo -u www-data php index.php 'oat\taoOutcomeUi\scripts\task\ExportDeliveryResults' <ClassId> --columns=all --submittedVersion=all`