### PR TITLE
fix: show item result review button only for locally authored items

### DIFF
--- a/model/ResultsService.php
+++ b/model/ResultsService.php
@@ -520,6 +520,7 @@ class ResultsService extends OntologyClassService
         $item['itemModel'] = '---';
         $item['label'] = $relatedItem['label'] ?? $undefinedStr;
         $item['uri'] = $relatedItem['uriResource'] ?? $undefinedStr;
+        $item['isLocal'] = strpos($relatedItem['uriResource'], LOCAL_NAMESPACE) !== false;
 
         // storing item info in memory to not hit the db for the same item again and again
         // when method "getStructuredVariables" are called multiple times in the same request

--- a/model/ResultsService.php
+++ b/model/ResultsService.php
@@ -520,7 +520,7 @@ class ResultsService extends OntologyClassService
         $item['itemModel'] = '---';
         $item['label'] = $relatedItem['label'] ?? $undefinedStr;
         $item['uri'] = $relatedItem['uriResource'] ?? $undefinedStr;
-        $item['isLocal'] = strpos($relatedItem['uriResource'], LOCAL_NAMESPACE) !== false;
+        $item['isLocal'] = strpos($relatedItem['uriResource'] ?? '', LOCAL_NAMESPACE) !== false;
 
         // storing item info in memory to not hit the db for the same item again and again
         // when method "getStructuredVariables" are called multiple times in the same request

--- a/views/templates/viewResult.tpl
+++ b/views/templates/viewResult.tpl
@@ -100,7 +100,7 @@ use oat\taoOutcomeUi\model\ResultsService;
                         <b><?= _dh($item['label']) ?></b>
                     </th>
                     <th>
-                        <?php if ($item['uri'] != 'unknown'): ?>
+                        <?php if ($item['isLocal']): ?>
                             <a href="#"
                                 data-delivery-id="<?=get_data('classUri')?>"
                                 data-result-id="<?=get_data('id')?>"


### PR DESCRIPTION
Result review page has the feature to review the answer, which shows the item and the answer selected. But for remote deliveries TAO doesn't have the necessary information to prepare the review, therefore the feature/button should be hidden.
 
Related to : https://oat-sa.atlassian.net/browse/REL-775
  
#### How to test
 

- Publish a test to remote instance
- Take the test
- Wait for the results to be synchronized back to TAO
- Verify that test session result screen does not show 'Review' buttons for individual item results
