### PR TITLE
fix: script for file upload will now reference to class instead of id

### DIFF
--- a/views/js/controller/viewResult.js
+++ b/views/js/controller/viewResult.js
@@ -169,7 +169,7 @@ define([
             });
 
             // bind the file download button
-            $('#fileDownload', $container).on('click', function() {
+            $('.download', $container).on('click', function() {
                 const variableUri = $(this).val();
                 $.fileDownload(downloadUrl, {
                     httpMethod: 'POST',


### PR DESCRIPTION
JS was referencing element id. Element id should be unique. I replace it to reference element class name