### PR TITLE
[Fix] Add missed variable

### DIFF
--- a/model/ResultsService.php
+++ b/model/ResultsService.php
@@ -1155,8 +1155,9 @@ class ResultsService extends OntologyClassService
             /** @var ContextTypePropertyColumn|VariableColumn $column */
             foreach ($columns as $column) {
                 $cellKey = $this->getColumnId($column);
-
                 $cellData[$cellKey] = null;
+                $values = [];
+
                 if ($column instanceof TraceVariableColumn && count($column->getDataProvider()->getCache()) > 0) {
                     $cellData[$cellKey] = self::filterCellData($column->getDataProvider()->getValue(new core_kernel_classes_Resource($result), $column), self::VARIABLES_FILTER_TRACE);
                 } elseif (count($column->getDataProvider()->cache) > 0) {


### PR DESCRIPTION
# Task
[RE-761](https://oat-sa.atlassian.net/browse/RE-761)

# PHP 8 migration
[ADF-1097](https://oat-sa.atlassian.net/browse/ADF-1097)
[ADF-1087](https://oat-sa.atlassian.net/browse/ADF-1087)
[ADF-1105](https://oat-sa.atlassian.net/browse/ADF-1105)

# Changes
* Added missed variable `$values`;
* Default value for `$values` is `[]`