### PR TITLE
Export all responses and all columns by default for a class and for a single delivery

### DIFF
--- a/controller/Results.php
+++ b/controller/Results.php
@@ -626,7 +626,7 @@ class Results extends \tao_actions_CommonModule
     public function export()
     {
         $exporter = $this->getExporter(new DeliveryCsvResultsExporterFactory());
-        return $this->returnTaskJson($exporter->createExportTask());
+        return $this->returnTaskJson($exporter->createExportTask(true));
     }
 
     /**

--- a/model/export/MultipleDeliveriesResultsExporter.php
+++ b/model/export/MultipleDeliveriesResultsExporter.php
@@ -47,7 +47,7 @@ class MultipleDeliveriesResultsExporter implements ResultsExporterInterface
 
     private $columnsToExport = [];
 
-    private $variableToExport = ResultsService::VARIABLES_FILTER_LAST_SUBMITTED;
+    private $variableToExport = ResultsService::VARIABLES_FILTER_ALL;
 
     private $storageOptions = [];
 

--- a/model/export/ResultsExporter.php
+++ b/model/export/ResultsExporter.php
@@ -119,18 +119,21 @@ class ResultsExporter implements ServiceLocatorAwareInterface
     }
 
     /**
+     * @param bool $allColumns
      * @return CallbackTaskInterface
      */
-    public function createExportTask()
+    public function createExportTask(bool $allColumns = false): CallbackTaskInterface
     {
         /** @var QueueDispatcherInterface $queueDispatcher */
         $queueDispatcher = $this->getServiceLocator()->get(QueueDispatcherInterface::SERVICE_ID);
 
         $columns = [];
 
-        // we need to convert every column object into array first
-        foreach ($this->getExporter()->getColumnsToExport() as $column) {
-            $columns[] = $column->toArray();
+        if (!$allColumns) {
+            // we need to convert every column object into array first
+            foreach ($this->getExporter()->getColumnsToExport() as $column) {
+                $columns[] = $column->toArray();
+            }
         }
 
         $label = $this->exportStrategy->getResourceToExport()->isClass()

--- a/model/export/SingleDeliveryResultsExporter.php
+++ b/model/export/SingleDeliveryResultsExporter.php
@@ -76,7 +76,7 @@ class SingleDeliveryResultsExporter implements ResultsExporterInterface
      *
      * @var string
      */
-    private $variableToExport = ResultsService::VARIABLES_FILTER_LAST_SUBMITTED;
+    private $variableToExport = ResultsService::VARIABLES_FILTER_ALL;
 
     /**
      * @var array
@@ -158,6 +158,7 @@ class SingleDeliveryResultsExporter implements ResultsExporterInterface
                 $columns = array_merge(
                     $this->columnsProvider->getTestTakerColumns(),
                     $this->columnsProvider->getDeliveryColumns(),
+                    $this->columnsProvider->getDeliveryExecutionColumns(),
                     $variables
                 );
             }


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/ADF-1214

We need to use a task queue for all operations for exporting results using the `Export CSV` button.
![image](https://user-images.githubusercontent.com/1053022/196424457-806cd005-0ed3-4ad3-85ae-5a9054337b5c.png)

How to test:
1. Pass a test with a few attempts for some items
2. Open the Result page and export a class which contains the needed delivery using the `Export CSV` button.
3. Export a single delivery using the `Export CSV` button. 
The final CSV should contain all columns (including delivery, grade, responses, delivery executions, and all trace variables) and all attempts with all responses.
Also, all exports will be taken by our taskQueue like before, but we will not generate the list of columns before creating a task