### PR TITLE
CSV export of duplicate items

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -22,8 +22,8 @@
  *
  */
 
+use oat\taoOutcomeUi\model\ContainerServiceProvider\ContainerServiceProvider;
 use oat\taoOutcomeUi\scripts\install\RegisterEvent;
-use oat\taoOutcomeUi\scripts\install\RegisterResultService;
 use oat\taoOutcomeUi\scripts\install\RegisterTestPluginService;
 use oat\taoOutcomeUi\scripts\install\SetUpQueueTasks;
 use oat\taoOutcomeUi\scripts\install\SetupSearchService;
@@ -85,6 +85,9 @@ return [
         'BASE_URL'            => ROOT_URL . 'taoOutcomeUi/',
     ],
     'extra'          => [
-        'structures' => dirname(__FILE__) . DIRECTORY_SEPARATOR . 'controller' . DIRECTORY_SEPARATOR . 'structures.xml'
+        'structures' => dirname(__FILE__) . DIRECTORY_SEPARATOR . 'controller' . DIRECTORY_SEPARATOR . 'structures.xml',
+    ],
+    'containerServiceProviders' => [
+        ContainerServiceProvider::class
     ]
 ];

--- a/model/ContainerServiceProvider/ContainerServiceProvider.php
+++ b/model/ContainerServiceProvider/ContainerServiceProvider.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoOutcomeUi\model\ContainerServiceProvider;
+
+use oat\generis\model\DependencyInjection\ContainerServiceProviderInterface;
+use oat\taoOutcomeUi\model\ItemResultStrategy;
+use oat\taoOutcomeUi\model\table\ColumnDataProvider\ColumnIdProvider;
+use oat\taoOutcomeUi\model\table\ColumnDataProvider\ColumnLabelProvider;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+use function Symfony\Component\DependencyInjection\Loader\Configurator\env;
+use function Symfony\Component\DependencyInjection\Loader\Configurator\param;
+use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
+
+class ContainerServiceProvider implements ContainerServiceProviderInterface
+{
+    private const DEFAULT_ITEM_RESULT_STRATEGY = 'defaultItemResultStrategy';
+
+    public function __invoke(ContainerConfigurator $configurator): void
+    {
+        $services = $configurator->services();
+        $parameters = $configurator->parameters();
+
+        $parameters->set(self::DEFAULT_ITEM_RESULT_STRATEGY, 'item_instance_label');
+        $parameters->set(
+            ItemResultStrategy::ENV_ITEM_RESULT_STRATEGY,
+            (string)env(ItemResultStrategy::ENV_ITEM_RESULT_STRATEGY)->default(self::DEFAULT_ITEM_RESULT_STRATEGY)
+        );
+
+        $services->set(ItemResultStrategy::class)
+            ->public()
+            ->args([param(ItemResultStrategy::ENV_ITEM_RESULT_STRATEGY)]);
+
+        $services->set(ColumnIdProvider::class)
+            ->public()
+            ->args([service(ItemResultStrategy::class)]);
+
+        $services->set(ColumnLabelProvider::class)
+            ->public()
+            ->args([service(ItemResultStrategy::class)]);
+    }
+}

--- a/model/ItemResultStrategy.php
+++ b/model/ItemResultStrategy.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2022 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoOutcomeUi\model;
+
+class ItemResultStrategy
+{
+    public const ENV_ITEM_RESULT_STRATEGY = 'ITEM_RESULT_STRATEGY';
+
+    private const ITEM_ENTITY_STRATEGY = 'item_entity';
+    private const ITEM_INSTANCE_LABEL_STRATEGY = 'item_instance_label';
+    private const ITEM_INSTANCE_ITEM_REF_STRATEGY = 'item_instance_item_ref';
+    private const ITEM_INSTANCE_LABEL_ITEM_REF_STRATEGY = 'item_instance_label_item_ref';
+
+    private string $strategy;
+
+    public function __construct(string $strategy)
+    {
+        $this->strategy = $strategy;
+    }
+
+    public function isItemEntityBased(): bool
+    {
+        return $this->strategy === self::ITEM_ENTITY_STRATEGY;
+    }
+
+    public function isItemInstanceLabelBased(): bool
+    {
+        return $this->strategy === self::ITEM_INSTANCE_LABEL_STRATEGY;
+    }
+
+    public function isItemInstanceItemRefBased(): bool
+    {
+        return $this->strategy === self::ITEM_INSTANCE_ITEM_REF_STRATEGY;
+    }
+
+    public function isItemInstanceLabelItemRefBased(): bool
+    {
+        return $this->strategy === self::ITEM_INSTANCE_LABEL_ITEM_REF_STRATEGY;
+    }
+}

--- a/model/export/SingleDeliveryResultsExporter.php
+++ b/model/export/SingleDeliveryResultsExporter.php
@@ -314,7 +314,7 @@ class SingleDeliveryResultsExporter implements ResultsExporterInterface
             foreach ($cells as $row) {
                 $rowResult = [];
                 foreach ($row as $rowKey => $rowVal) {
-                    $rowResult[$columnNames[$rowKey]] = $rowVal[0];
+                    $rowResult[$rowKey] = $rowVal[0];
                 }
                 $result[] = $rowResult;
             }
@@ -322,10 +322,7 @@ class SingleDeliveryResultsExporter implements ResultsExporterInterface
 
         $this->sortByStartDate($result);
 
-        //If there are no executions yet, the file is exported but contains only the header
-        if (empty($result)) {
-            $result = [array_fill_keys($columnNames, '')];
-        }
+        array_unshift($result, $columnNames);
 
         $exporter = $this->getExporter($result);
 
@@ -352,7 +349,7 @@ class SingleDeliveryResultsExporter implements ResultsExporterInterface
      */
     protected function getExportData($exporter)
     {
-        return $exporter->export(true, false, ',', '"', false);
+        return $exporter->export(false, false, ',', '"', false);
     }
 
     /**

--- a/model/table/ColumnDataProvider/ColumnIdProvider.php
+++ b/model/table/ColumnDataProvider/ColumnIdProvider.php
@@ -1,0 +1,76 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2022 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoOutcomeUi\model\table\ColumnDataProvider;
+
+use oat\taoOutcomeUi\model\ItemResultStrategy;
+use oat\taoOutcomeUi\model\table\ContextTypePropertyColumn;
+use oat\taoOutcomeUi\model\table\DeliveryExecutionColumn;
+use oat\taoOutcomeUi\model\table\TestCenterColumn;
+use oat\taoOutcomeUi\model\table\TraceVariableColumn;
+use oat\taoOutcomeUi\model\table\VariableColumn;
+use tao_models_classes_table_Column;
+
+class ColumnIdProvider
+{
+    private ItemResultStrategy $itemResultStrategy;
+
+    public function __construct(ItemResultStrategy $itemResultStrategy)
+    {
+        $this->itemResultStrategy = $itemResultStrategy;
+    }
+
+    public function provide(tao_models_classes_table_Column $column): string
+    {
+        switch (get_class($column)){
+            case ContextTypePropertyColumn::class:
+                return $column->getProperty()->getUri() . '_' . $column->getContextType();
+            case TestCenterColumn::class:
+                return $column->getProperty()->getUri();
+            case VariableColumn::class:
+                return $this->provideVariableColumnId($column);
+            case TraceVariableColumn::class:
+            case DeliveryExecutionColumn::class:
+                return $column->getContextIdentifier() . '_' . $column->getIdentifier();
+            default:
+                return $this->createColumnDataHash($column->getLabel());
+        }
+    }
+
+    public function createColumnDataHash(string ...$elements): string
+    {
+        return md5(implode($elements));
+    }
+
+    private function provideVariableColumnId(VariableColumn $variableColumn): string
+    {
+        if (!$this->itemResultStrategy->isItemEntityBased()) {
+            return $this->createColumnDataHash(
+                $variableColumn->getContextIdentifier(),
+                $variableColumn->getRefId() ?? '',
+                $variableColumn->getIdentifier()
+            );
+        }
+
+        return $variableColumn->getContextIdentifier() . '_' . $variableColumn->getIdentifier();
+    }
+}

--- a/model/table/ColumnDataProvider/ColumnLabelProvider.php
+++ b/model/table/ColumnDataProvider/ColumnLabelProvider.php
@@ -1,0 +1,69 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2022 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoOutcomeUi\model\table\ColumnDataProvider;
+
+use oat\taoOutcomeUi\model\ItemResultStrategy;
+use oat\taoOutcomeUi\model\table\VariableColumn;
+use tao_models_classes_table_Column;
+
+class ColumnLabelProvider
+{
+    private const LABEL_SEPARATOR = '-';
+
+    private ItemResultStrategy $itemResultStrategy;
+
+    public function __construct(ItemResultStrategy $itemResultStrategy)
+    {
+        $this->itemResultStrategy = $itemResultStrategy;
+    }
+
+    public function provide(tao_models_classes_table_Column $column): string
+    {
+        if($column instanceof VariableColumn) {
+            if (
+                $this->itemResultStrategy->isItemInstanceLabelItemRefBased()
+                && $column->getRefId() !== null
+            ) {
+                return $this->createLabel(
+                    $column->getRefId(),
+                    $column->getContextLabel(),
+                    $column->getIdentifier()
+                );
+            }
+
+            if (
+                $this->itemResultStrategy->isItemInstanceItemRefBased()
+                && $column->getRefId() !== null
+            ) {
+                return $this->createLabel($column->getRefId(), $column->getIdentifier());
+            }
+        }
+
+        return $column->getLabel();
+    }
+
+    public function createLabel(string ...$elements): string
+    {
+        return implode(self::LABEL_SEPARATOR, $elements);
+    }
+}

--- a/model/table/VariableColumn.php
+++ b/model/table/VariableColumn.php
@@ -22,7 +22,9 @@
 
 namespace oat\taoOutcomeUi\model\table;
 
+use oat\taoOutcomeUi\model\ItemResultStrategy;
 use \tao_models_classes_table_Column;
+use tao_models_classes_table_DataProvider;
 
 /**
  * Short description of class oat\taoOutcomeUi\model\table\VariableColumn
@@ -68,7 +70,12 @@ abstract class VariableColumn extends tao_models_classes_table_Column
      */
     private $columnType;
 
+    /** @var string|null */
+    private $refId;
+
     // --- OPERATIONS ---
+    /** @var ItemResultStrategy */
+    private $itemResultStrategy = null;
 
     /**
      *
@@ -77,15 +84,13 @@ abstract class VariableColumn extends tao_models_classes_table_Column
      */
     protected static function fromArray($array)
     {
-        $returnValue = null;
-
         $contextId = $array['contextId'];
         $contextLabel = $array['contextLabel'];
         $variableIdentifier =  $array['variableIdentifier'];
         $columnType =  $array['columnType'];
-        $returnValue = new static($contextId, $contextLabel, $variableIdentifier, $columnType);
+        $refId = $array['refId'] ?? null;
 
-        return $returnValue;
+        return new static($contextId, $contextLabel, $variableIdentifier, $columnType, $refId);
     }
 
     /**
@@ -94,14 +99,16 @@ abstract class VariableColumn extends tao_models_classes_table_Column
      * @param string $contextLabel
      * @param string $identifier
      * @param string|null $columnType
+     * @param string|null $refId
      */
-    public function __construct($contextIdentifier, $contextLabel, $identifier, $columnType = null)
+    public function __construct($contextIdentifier, $contextLabel, $identifier, $columnType = null, $refId = null)
     {
         parent::__construct($contextLabel . "-" . $identifier);
         $this->identifier = $identifier;
         $this->contextIdentifier = $contextIdentifier;
         $this->contextLabel = $contextLabel;
         $this->columnType = $columnType;
+        $this->refId = $refId;
     }
 
     public function getColumnType()
@@ -113,7 +120,7 @@ abstract class VariableColumn extends tao_models_classes_table_Column
     {
         $this->dataProvider = $provider;
     }
-    
+
     /**
      * Short description of method getDataProvider
      *
@@ -131,7 +138,7 @@ abstract class VariableColumn extends tao_models_classes_table_Column
      *
      * @access public
      * @author Joel Bout, <joel.bout@tudor.lu>
-     * @return core_kernel_classes_Resource
+     * @return string
      */
     public function getContextIdentifier()
     {
@@ -165,14 +172,28 @@ abstract class VariableColumn extends tao_models_classes_table_Column
         $returnValue['contextLabel'] = $this->contextLabel;
         $returnValue['variableIdentifier'] = $this->identifier;
         $returnValue['columnType'] = $this->getColumnType();
+        $returnValue['refId'] = $this->getRefId();
 
-        return (array) $returnValue;
+        return $returnValue;
     }
-    
+
     /**
      * Returns the variable type of the column
      *
      * @return string
      */
     abstract public function getVariableType();
+
+    /**
+     * @return string|null
+     */
+    public function getRefId(): ?string
+    {
+        return $this->refId;
+    }
+
+    public function getContextLabel(): string
+    {
+        return $this->contextLabel;
+    }
 }


### PR DESCRIPTION
# [TR-4908](https://oat-sa.atlassian.net/browse/TR-4908)

## Summary
The goals of change to separate duplicated items in exported csv results
4 different strategy for items result export provided: 
- item_entity
[results_export_delivery_of_test_5_asdasdad_i638f606c153a7182f8ea00bf85fc928e_2022120618570427.csv](https://github.com/oat-sa/extension-tao-outcomeui/files/10169041/results_export_delivery_of_test_5_asdasdad_i638f606c153a7182f8ea00bf85fc928e_2022120618570427.csv)

- item_instance_label
[results_export_delivery_of_test_5_asdasdad_i638f606c153a7182f8ea00bf85fc928e_2022120618560576.csv](https://github.com/oat-sa/extension-tao-outcomeui/files/10169038/results_export_delivery_of_test_5_asdasdad_i638f606c153a7182f8ea00bf85fc928e_2022120618560576.csv)

- item_instance_item_ref
[results_export_delivery_of_test_5_asdasdad_i638f606c153a7182f8ea00bf85fc928e_2022120618535894.csv](https://github.com/oat-sa/extension-tao-outcomeui/files/10169024/results_export_delivery_of_test_5_asdasdad_i638f606c153a7182f8ea00bf85fc928e_2022120618535894.csv)

- item_instance_label_item_ref
[results_export_delivery_of_test_5_asdasdad_i638f606c153a7182f8ea00bf85fc928e_2022120618522588.csv](https://github.com/oat-sa/extension-tao-outcomeui/files/10169013/results_export_delivery_of_test_5_asdasdad_i638f606c153a7182f8ea00bf85fc928e_2022120618522588.csv)


## How to test
- install branch
- create and execute delivery with multiple times used item
- export csv in result page
- apply different strategies

## TODO
- validate different corner cases of functionality (preview on `Export Table` page)
- validate possibility to adjust existed or create new tests
- adjust README