### PR TITLE
backport: missing trace variables

### DIFF
--- a/model/ResultsService.php
+++ b/model/ResultsService.php
@@ -1158,6 +1158,8 @@ class ResultsService extends OntologyClassService
                 $cellData[$cellKey] = null;
                 if ($column instanceof TraceVariableColumn && count($column->getDataProvider()->getCache()) > 0) {
                     $cellData[$cellKey] = self::filterCellData($column->getDataProvider()->getValue(new core_kernel_classes_Resource($result), $column), self::VARIABLES_FILTER_TRACE);
+
+                    continue;
                 } elseif (count($column->getDataProvider()->cache) > 0) {
                     // grade or response column values
                     $cellData[$cellKey] = self::filterCellData($column->getDataProvider()->getValue(new core_kernel_classes_Resource($result), $column), $filter);


### PR DESCRIPTION
The change fixes a regression in result export table which appear since [this line](https://github.com/oat-sa/extension-tao-outcomeui/pull/452/files#diff-fdfe15441eaef51a6aaa3ef6c8ca797190f88a3d3b29c5da35694502f60555aeR1260) added, where $values is empty array.

Also on 2022.08 release there was no empty values array definition on line [R1182](https://github.com/oat-sa/extension-tao-outcomeui/pull/452/files#diff-fdfe15441eaef51a6aaa3ef6c8ca797190f88a3d3b29c5da35694502f60555aeR1182) so values from previous column/iteration was written to trace variable column as we can see in the bug ticket.