### PR TITLE
fix: leave columns building only in worker task runtime

### DIFF
--- a/controller/ResultTable.php
+++ b/controller/ResultTable.php
@@ -167,7 +167,7 @@ class ResultTable extends \tao_actions_CommonModule
             'columns' => $this->adjustColumnByLabelAndId(
                 $this->getColumnsProvider()->getTestTakerColumns()
             ),
-            'first'   => true
+            'first' => true
         ]);
     }
 
@@ -259,23 +259,22 @@ class ResultTable extends \tao_actions_CommonModule
     }
 
     /**
-     * @return ColumnsProvider
+     * @throws \common_exception_NotFound
+     * @throws common_Exception
      */
-    private function getColumnsProvider()
+    private function getColumnsProvider(): ColumnsProvider
     {
         return new ColumnsProvider($this->getDeliveryUri(), ResultsService::singleton());
     }
 
 
     /**
-     * @param DeliveryResultsExporterFactoryInterface $deliveryResultsExporterFactory
-     * @return ResultsExporter
      * @throws \common_exception_MissingParameter
      * @throws \common_exception_NotFound
      * @throws common_Exception
      */
-    private function getExporterService(DeliveryResultsExporterFactoryInterface $deliveryResultsExporterFactory)
-    {
+    private function getExporterService(DeliveryResultsExporterFactoryInterface $deliveryResultsExporterFactory
+    ): ResultsExporter {
         /** @var ResultsExporter $exporter */
         $exporter = $this->propagate(
             new ResultsExporter(
@@ -286,7 +285,9 @@ class ResultTable extends \tao_actions_CommonModule
         );
 
         if ($this->hasRequestParameter(self::PARAMETER_COLUMNS)) {
-            $exporter->setColumnsToExport($this->getRawParameter(self::PARAMETER_COLUMNS));
+            $exporter->setColumnsToExport(
+                $this->decodeColumns($this->getRawParameter(self::PARAMETER_COLUMNS))
+            );
         }
 
         if ($this->hasRequestParameter(self::PARAMETER_FILTER)) {
@@ -326,16 +327,22 @@ class ResultTable extends \tao_actions_CommonModule
         return $exporter;
     }
 
+    private function decodeColumns(string $columnsJson): array
+    {
+        return ($columnsData = json_decode($columnsJson, true)) !== null && json_last_error() === JSON_ERROR_NONE
+            ? (array)$columnsData
+            : [];
+    }
+
     private function getTime($date = '')
     {
         return $date ? strtotime($date) : 0;
     }
 
     /**
-     * @return string
      * @throws common_Exception
      */
-    private function getDeliveryUri()
+    private function getDeliveryUri(): string
     {
         if (!$this->hasRequestParameter(self::PARAMETER_DELIVERY_URI)) {
             throw new common_Exception('Parameter "' . self::PARAMETER_DELIVERY_URI . '" missing');
@@ -344,10 +351,7 @@ class ResultTable extends \tao_actions_CommonModule
         return \tao_helpers_Uri::decode($this->getRequestParameter(self::PARAMETER_DELIVERY_URI));
     }
 
-    /**
-     * @return ResultsService
-     */
-    private function getResultService()
+    private function getResultService(): ResultsService
     {
         return $this->getServiceLocator()->get(ResultsService::SERVICE_ID);
     }

--- a/controller/ResultTable.php
+++ b/controller/ResultTable.php
@@ -267,16 +267,14 @@ class ResultTable extends \tao_actions_CommonModule
         return new ColumnsProvider($this->getDeliveryUri(), ResultsService::singleton());
     }
 
-
-    /**
+     /**
      * @throws \common_exception_MissingParameter
      * @throws \common_exception_NotFound
      * @throws common_Exception
      */
     private function getExporterService(
         DeliveryResultsExporterFactoryInterface $deliveryResultsExporterFactory
-    ): ResultsExporter
-    {
+    ): ResultsExporter {
         /** @var ResultsExporter $exporter */
         $exporter = $this->propagate(
             new ResultsExporter(

--- a/controller/ResultTable.php
+++ b/controller/ResultTable.php
@@ -273,8 +273,10 @@ class ResultTable extends \tao_actions_CommonModule
      * @throws \common_exception_NotFound
      * @throws common_Exception
      */
-    private function getExporterService(DeliveryResultsExporterFactoryInterface $deliveryResultsExporterFactory
-    ): ResultsExporter {
+    private function getExporterService(
+        DeliveryResultsExporterFactoryInterface $deliveryResultsExporterFactory
+    ): ResultsExporter
+    {
         /** @var ResultsExporter $exporter */
         $exporter = $this->propagate(
             new ResultsExporter(

--- a/model/export/ResultsExporter.php
+++ b/model/export/ResultsExporter.php
@@ -15,9 +15,11 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2017 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ * Copyright (c) 2017-2022 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
  *
  */
+
+declare(strict_types=1);
 
 namespace oat\taoOutcomeUi\model\export;
 
@@ -40,30 +42,30 @@ class ResultsExporter implements ServiceLocatorAwareInterface
     use OntologyAwareTrait;
     use ServiceLocatorAwareTrait;
 
-    private $exportStrategy;
-    /**
-     * @var ResultsService
-     */
-    private $resultsService;
-    private $columns;
+    private ResultsExporterInterface $exportStrategy;
+    private ResultsService $resultsService;
+    private array $columns = [];
 
     /**
-     * ResultsExporter constructor.
-     * @param $resource
-     * @param ResultsService $resultsService
-     * @param DeliveryResultsExporterFactoryInterface|null $deliveryResultsExporterFactory
      * @throws common_exception_NotFound
      */
-    public function __construct($resource, ResultsService $resultsService, DeliveryResultsExporterFactoryInterface $deliveryResultsExporterFactory = null)
-    {
-        $resource = $this->getResource($resource);
+    public function __construct(
+        string $resourceUri,
+        ResultsService $resultsService,
+        DeliveryResultsExporterFactoryInterface $deliveryResultsExporterFactory = null
+    ) {
+        $resource = $this->getResource($resourceUri);
 
         if ($deliveryResultsExporterFactory === null) {
             $deliveryResultsExporterFactory = new DeliveryCsvResultsExporterFactory();
         }
 
         if ($resource->isClass()) {
-            $this->exportStrategy = new MultipleDeliveriesResultsExporter($this->getClass($resource->getUri()), $resultsService, $deliveryResultsExporterFactory);
+            $this->exportStrategy = new MultipleDeliveriesResultsExporter(
+                $this->getClass($resource->getUri()),
+                $resultsService,
+                $deliveryResultsExporterFactory
+            );
         } else {
             $this->exportStrategy = $deliveryResultsExporterFactory->getDeliveryResultsExporter(
                 $resource,
@@ -73,44 +75,33 @@ class ResultsExporter implements ServiceLocatorAwareInterface
         $this->resultsService = $resultsService;
     }
 
-    /**
-     * @return ResultsExporterInterface
-     */
-    public function getExporter()
+    public function getExporter(): ResultsExporterInterface
     {
         $this->exportStrategy->setServiceLocator($this->getServiceLocator());
 
         return $this->exportStrategy;
     }
 
-    public function setColumnsToExport($columnsToExport): self
+    public function setColumnsToExport(array $columnsToExport): self
     {
         $this->columns = $columnsToExport;
 
         return $this;
     }
 
-    /**
-     * @param string $variableToExport
-     * @return ResultsExporter
-     */
-    public function setVariableToExport($variableToExport)
+    public function setVariableToExport(string $variableToExport): self
     {
         $this->getExporter()->setVariableToExport($variableToExport);
         return $this;
     }
 
-    public function setFiltersToExport($filters)
+    public function setFiltersToExport(array $filters): self
     {
         $this->getExporter()->setFiltersToExport($filters);
         return $this;
     }
 
-    /**
-     * @param null|string $destination
-     * @return string
-     */
-    public function export($destination = null)
+    public function export(string $destination = null): string
     {
         return $this->getExporter()
             ->setColumnsToExport($this->columns)
@@ -126,8 +117,16 @@ class ResultsExporter implements ServiceLocatorAwareInterface
         $queueDispatcher = $this->getServiceLocator()->get(QueueDispatcherInterface::SERVICE_ID);
 
         $label = $this->exportStrategy->getResourceToExport()->isClass()
-            ? __('%s results export for delivery class "%s"', $this->exportStrategy->getResultFormat(), $this->exportStrategy->getResourceToExport()->getLabel())
-            : __('%s results export for delivery "%s"', $this->exportStrategy->getResultFormat(), $this->exportStrategy->getResourceToExport()->getLabel());
+            ? __(
+                '%s results export for delivery class "%s"',
+                $this->exportStrategy->getResultFormat(),
+                $this->exportStrategy->getResourceToExport()->getLabel()
+            )
+            : __(
+                '%s results export for delivery "%s"',
+                $this->exportStrategy->getResultFormat(),
+                $this->exportStrategy->getResourceToExport()->getLabel()
+            );
 
         return $queueDispatcher->createTask(
             new ExportDeliveryResults(),

--- a/model/export/ResultsExporter.php
+++ b/model/export/ResultsExporter.php
@@ -45,7 +45,7 @@ class ResultsExporter implements ServiceLocatorAwareInterface
      * @var ResultsService
      */
     private $resultsService;
-    private string $columns;
+    private $columns;
 
     /**
      * ResultsExporter constructor.
@@ -83,7 +83,7 @@ class ResultsExporter implements ServiceLocatorAwareInterface
         return $this->exportStrategy;
     }
 
-    public function setColumnsToExport(string $columnsToExport): self
+    public function setColumnsToExport($columnsToExport): self
     {
         $this->columns = $columnsToExport;
 

--- a/model/export/SingleDeliverySqlResultsExporter.php
+++ b/model/export/SingleDeliverySqlResultsExporter.php
@@ -63,9 +63,6 @@ class SingleDeliverySqlResultsExporter extends SingleDeliveryResultsExporter
         return $exporter->export();
     }
 
-    /**
-     * @inheritdoc
-     */
     protected function getExporter(array $data): AbstractFileExporter
     {
         foreach ($this->getColumnsToExport() as $columnData) {

--- a/model/export/SingleDeliverySqlResultsExporter.php
+++ b/model/export/SingleDeliverySqlResultsExporter.php
@@ -19,8 +19,11 @@
  *
  */
 
+declare(strict_types=1);
+
 namespace oat\taoOutcomeUi\model\export;
 
+use oat\tao\model\export\implementation\AbstractFileExporter;
 use oat\tao\model\export\implementation\sql\ExportedColumn;
 use oat\tao\model\export\implementation\SqlExporter;
 use oat\taoOutcomeUi\model\table\VariableColumn;
@@ -35,7 +38,7 @@ class SingleDeliverySqlResultsExporter extends SingleDeliveryResultsExporter
 {
     public const RESULT_FORMAT = 'SQL';
 
-    private $mappingVarTypes = [
+    private array $mappingVarTypes = [
         Variable::TYPE_VARIABLE_INTEGER => ExportedColumn::TYPE_INTEGER,
         Variable::TYPE_VARIABLE_BOOLEAN => ExportedColumn::TYPE_BOOLEAN,
         Variable::TYPE_VARIABLE_IDENTIFIER => ExportedColumn::TYPE_VARCHAR,
@@ -43,19 +46,19 @@ class SingleDeliverySqlResultsExporter extends SingleDeliveryResultsExporter
         Variable::TYPE_VARIABLE_FLOAT => ExportedColumn::TYPE_DECIMAL
     ];
 
-    private $mappingFieldsTypes = [
-        'Start Date'                => ExportedColumn::TYPE_TIMESTAMP,
-        'End Date'                  => ExportedColumn::TYPE_TIMESTAMP,
-        'Compilation Time'          => ExportedColumn::TYPE_INTEGER,
-        'Start Delivery Execution'  => ExportedColumn::TYPE_TIMESTAMP,
-        'End Delivery Execution'    => ExportedColumn::TYPE_TIMESTAMP
+    private array $mappingFieldsTypes = [
+        'Start Date' => ExportedColumn::TYPE_TIMESTAMP,
+        'End Date' => ExportedColumn::TYPE_TIMESTAMP,
+        'Compilation Time' => ExportedColumn::TYPE_INTEGER,
+        'Start Delivery Execution' => ExportedColumn::TYPE_TIMESTAMP,
+        'End Delivery Execution' => ExportedColumn::TYPE_TIMESTAMP
     ];
 
     /**
      * @param SqlExporter $exporter
      * @return string
      */
-    protected function getExportData($exporter)
+    protected function getExportData(AbstractFileExporter $exporter): string
     {
         return $exporter->export();
     }
@@ -63,7 +66,7 @@ class SingleDeliverySqlResultsExporter extends SingleDeliveryResultsExporter
     /**
      * @inheritdoc
      */
-    protected function getExporter(array $data)
+    protected function getExporter(array $data): AbstractFileExporter
     {
         foreach ($this->getColumnsToExport() as $columnData) {
             if ($columnData instanceof VariableColumn) {

--- a/model/export/SingleDeliverySqlResultsExporter.php
+++ b/model/export/SingleDeliverySqlResultsExporter.php
@@ -54,10 +54,6 @@ class SingleDeliverySqlResultsExporter extends SingleDeliveryResultsExporter
         'End Delivery Execution' => ExportedColumn::TYPE_TIMESTAMP
     ];
 
-    /**
-     * @param SqlExporter $exporter
-     * @return string
-     */
     protected function getExportData(AbstractFileExporter $exporter): string
     {
         return $exporter->export();

--- a/scripts/task/ExportDeliveryResults.php
+++ b/scripts/task/ExportDeliveryResults.php
@@ -41,6 +41,7 @@ use oat\taoOutcomeUi\model\ResultsService;
 use Zend\ServiceManager\ServiceLocatorAwareTrait;
 use Zend\ServiceManager\ServiceLocatorAwareInterface;
 
+// phpcs:disable Generic.Files.LineLength
 /**
  * ExportDeliveryResults action, can be called either during a http request or from cli.
  *
@@ -57,6 +58,7 @@ use Zend\ServiceManager\ServiceLocatorAwareInterface;
  * ```
  * @author Gyula Szucs <gyula@taotesting.com>
  */
+// phpcs:enable
 class ExportDeliveryResults implements Action, ServiceLocatorAwareInterface, WorkerContextAwareInterface
 {
     use ServiceLocatorAwareTrait;
@@ -66,11 +68,11 @@ class ExportDeliveryResults implements Action, ServiceLocatorAwareInterface, Wor
     /**
      * Possible CLI values for columns
      */
-    const COLUMNS_CLI_VALUE_ALL = 'all';
-    const COLUMNS_CLI_VALUE_TEST_TAKER = 'tt';
-    const COLUMNS_CLI_VALUE_DELIVERY = 'delivery';
-    const COLUMNS_CLI_VALUE_GRADES = 'grades';
-    const COLUMNS_CLI_VALUE_RESPONSES = 'responses';
+    private const COLUMNS_CLI_VALUE_ALL = 'all';
+    private const COLUMNS_CLI_VALUE_TEST_TAKER = 'tt';
+    private const COLUMNS_CLI_VALUE_DELIVERY = 'delivery';
+    private const COLUMNS_CLI_VALUE_GRADES = 'grades';
+    private const COLUMNS_CLI_VALUE_RESPONSES = 'responses';
 
     private core_kernel_classes_Resource $resourceToExport;
     private ?ResultsExporter $exporterService = null;
@@ -247,14 +249,11 @@ class ExportDeliveryResults implements Action, ServiceLocatorAwareInterface, Wor
                         break;
 
                     case '--submittedVersion':
-                        if (!in_array(
-                            $value,
-                            [
-                                ResultsService::VARIABLES_FILTER_ALL,
-                                ResultsService::VARIABLES_FILTER_FIRST_SUBMITTED,
-                                ResultsService::VARIABLES_FILTER_LAST_SUBMITTED
-                            ]
-                        )) {
+                        if (!in_array($value, [
+                            ResultsService::VARIABLES_FILTER_ALL,
+                            ResultsService::VARIABLES_FILTER_FIRST_SUBMITTED,
+                            ResultsService::VARIABLES_FILTER_LAST_SUBMITTED
+                        ])) {
                             throw new InvalidArgumentException(
                                 sprintf(
                                     'Invalid submitted version of variables %s. Valid options: %s',

--- a/scripts/task/ExportDeliveryResults.php
+++ b/scripts/task/ExportDeliveryResults.php
@@ -157,7 +157,7 @@ class ExportDeliveryResults implements Action, ServiceLocatorAwareInterface, Wor
 
         if ($this->isWorkerContext()) {
             // Columns to be exported, if defined
-            if (isset($params[1]) && is_array($params[1])) {
+            if (isset($params[1])) {
                 $this->columns = $params[1];
             }
 

--- a/scripts/task/ExportDeliveryResults.php
+++ b/scripts/task/ExportDeliveryResults.php
@@ -249,14 +249,16 @@ class ExportDeliveryResults implements Action, ServiceLocatorAwareInterface, Wor
                         break;
 
                     case '--submittedVersion':
-                        if (!in_array(
-                            $value,
-                            [
-                                ResultsService::VARIABLES_FILTER_ALL,
-                                ResultsService::VARIABLES_FILTER_FIRST_SUBMITTED,
-                                ResultsService::VARIABLES_FILTER_LAST_SUBMITTED
-                            ]
-                        )) {
+                        if (
+                            !in_array(
+                                $value,
+                                [
+                                    ResultsService::VARIABLES_FILTER_ALL,
+                                    ResultsService::VARIABLES_FILTER_FIRST_SUBMITTED,
+                                    ResultsService::VARIABLES_FILTER_LAST_SUBMITTED
+                                ]
+                            )
+                        ) {
                             throw new InvalidArgumentException(
                                 sprintf(
                                     'Invalid submitted version of variables %s. Valid options: %s',

--- a/scripts/task/ExportDeliveryResults.php
+++ b/scripts/task/ExportDeliveryResults.php
@@ -249,11 +249,14 @@ class ExportDeliveryResults implements Action, ServiceLocatorAwareInterface, Wor
                         break;
 
                     case '--submittedVersion':
-                        if (!in_array($value, [
-                            ResultsService::VARIABLES_FILTER_ALL,
-                            ResultsService::VARIABLES_FILTER_FIRST_SUBMITTED,
-                            ResultsService::VARIABLES_FILTER_LAST_SUBMITTED
-                        ])) {
+                        if (!in_array(
+                            $value,
+                            [
+                                ResultsService::VARIABLES_FILTER_ALL,
+                                ResultsService::VARIABLES_FILTER_FIRST_SUBMITTED,
+                                ResultsService::VARIABLES_FILTER_LAST_SUBMITTED
+                            ]
+                        )) {
                             throw new InvalidArgumentException(
                                 sprintf(
                                     'Invalid submitted version of variables %s. Valid options: %s',

--- a/scripts/task/ExportDeliveryResults.php
+++ b/scripts/task/ExportDeliveryResults.php
@@ -203,11 +203,13 @@ class ExportDeliveryResults implements Action, ServiceLocatorAwareInterface, Wor
                     break;
 
                 case '--submittedVersion':
-                    if (!in_array($value, [
-                        ResultsService::VARIABLES_FILTER_ALL,
-                        ResultsService::VARIABLES_FILTER_FIRST_SUBMITTED,
-                        ResultsService::VARIABLES_FILTER_LAST_SUBMITTED
-                    ])) {
+                    if (
+                        !in_array($value, [
+                            ResultsService::VARIABLES_FILTER_ALL,
+                            ResultsService::VARIABLES_FILTER_FIRST_SUBMITTED,
+                            ResultsService::VARIABLES_FILTER_LAST_SUBMITTED
+                        ])
+                    ) {
                         throw new InvalidArgumentException(
                             sprintf(
                                 'Invalid submitted version of variables %s. Valid options: %s',

--- a/scripts/task/ExportDeliveryResults.php
+++ b/scripts/task/ExportDeliveryResults.php
@@ -19,9 +19,15 @@
  *
  */
 
+declare(strict_types=1);
+
 namespace oat\taoOutcomeUi\scripts\task;
 
-use common_report_Report as Report;
+use common_exception_NotFound;
+use Exception;
+use InvalidArgumentException;
+use oat\oatbox\reporting\Report as Report;
+use core_kernel_classes_Resource;
 use oat\generis\model\OntologyAwareTrait;
 use oat\oatbox\action\Action;
 use oat\tao\model\taskQueue\Task\WorkerContextAwareInterface;
@@ -66,26 +72,19 @@ class ExportDeliveryResults implements Action, ServiceLocatorAwareInterface, Wor
     const COLUMNS_CLI_VALUE_GRADES = 'grades';
     const COLUMNS_CLI_VALUE_RESPONSES = 'responses';
 
-    /**
-     * @var \core_kernel_classes_Resource
-     */
-    private $resourceToExport;
-    private $exporterService;
-    private $columns = [];
-    private $submittedVersion;
-    private $destination;
-    private $filters = [];
-    private $format;
-    /**
-     * @var DeliveryResultsExporterFactoryInterface
-     */
-    private $deliveryResultsExporterFactory;
+    private core_kernel_classes_Resource $resourceToExport;
+    private ?ResultsExporter $exporterService = null;
+    private array $columns = [];
+    private ?string $submittedVersion = null;
+    private ?string $destination = null;
+    private array $filters = [];
+    private ?DeliveryResultsExporterFactoryInterface $deliveryResultsExporterFactory = null;
 
     /**
      * @param array $params
      * @return Report
      */
-    public function __invoke($params)
+    public function __invoke($params): Report
     {
         $this->loadExtensions();
 
@@ -104,23 +103,31 @@ class ExportDeliveryResults implements Action, ServiceLocatorAwareInterface, Wor
             $msg = $fileName
                 ? $this->isWorkerContext()
                     ? __('Results of "%s" successfully exported', $this->resourceToExport->getLabel())
-                    : __('Results of "%s" successfully exported into "%s"', $this->resourceToExport->getLabel(), $fileName)
+                    : __(
+                        'Results of "%s" successfully exported into "%s"',
+                        $this->resourceToExport->getLabel(),
+                        $fileName
+                    )
                 : __('Nothing to export for "%s"', $this->resourceToExport->getLabel());
 
             return Report::createSuccess($msg, $fileName);
-        } catch (\Exception $e) {
-            return Report::createFailure($e->getMessage());
+        } catch (Exception $e) {
+            return Report::createError($e->getMessage());
         }
     }
 
     /**
      * @return ResultsExporter
-     * @throws \common_exception_NotFound
+     * @throws common_exception_NotFound
      */
     private function getExporterService()
     {
         if (is_null($this->exporterService)) {
-            $this->exporterService = new ResultsExporter($this->resourceToExport, ResultsService::singleton(), $this->deliveryResultsExporterFactory);
+            $this->exporterService = new ResultsExporter(
+                $this->resourceToExport->getUri(),
+                ResultsService::singleton(),
+                $this->deliveryResultsExporterFactory
+            );
             $this->exporterService->setServiceLocator($this->getServiceLocator());
         }
 
@@ -130,7 +137,7 @@ class ExportDeliveryResults implements Action, ServiceLocatorAwareInterface, Wor
     /**
      * Load the required TAO extensions (for constants)
      */
-    private function loadExtensions()
+    private function loadExtensions(): void
     {
         $this->getServiceLocator()->get(\common_ext_ExtensionsManager::SERVICE_ID)->getExtensionById('taoOutcomeUi');
         $this->getServiceLocator()->get(\common_ext_ExtensionsManager::SERVICE_ID)->getExtensionById('taoDeliveryRdf');
@@ -144,20 +151,21 @@ class ExportDeliveryResults implements Action, ServiceLocatorAwareInterface, Wor
      * - $params[1]: columns (optional, array|string)
      * - $params[2]: submittedVersion (optional, string)
      *
-     * @param array $params
      */
-    private function parseParams($params)
+    private function parseParams(array $params): void
     {
         // Delivery or Class Uri
         if (!isset($params[0])) {
-            throw new \InvalidArgumentException('Delivery or class uri missing. Please provide it as the first argument.');
+            throw new InvalidArgumentException(
+                'Delivery or class uri missing. Please provide it as the first argument.'
+            );
         }
 
         $this->resourceToExport = $this->getResource($params[0]);
 
         if ($this->isWorkerContext()) {
             // Columns to be exported, if defined
-            if (isset($params[1])) {
+            if (isset($params[1]) && is_array($params[1])) {
                 $this->columns = $params[1];
             }
 
@@ -192,42 +200,71 @@ class ExportDeliveryResults implements Action, ServiceLocatorAwareInterface, Wor
                         $invalidValues = array_diff($columns, $this->getPossibleColumnValues());
 
                         if (count($invalidValues)) {
-                            throw new \InvalidArgumentException('Invalid columns value(s) "' . implode(', ', $invalidValues) . '". Valid options: ' . implode(', ', $this->getPossibleColumnValues()));
+                            throw new InvalidArgumentException(
+                                'Invalid columns value(s) "' . implode(
+                                    ', ',
+                                    $invalidValues
+                                ) . '". Valid options: ' . implode(', ', $this->getPossibleColumnValues())
+                            );
                         }
 
                         if (in_array(self::COLUMNS_CLI_VALUE_ALL, $columns)) {
-                            // do nothing because SingleDeliveryResultsExporter will use all columns by default if no columns specified
+                            // skip cause SingleDeliveryResultsExporter use all columns by default
                             break;
                         }
 
                         foreach ($columns as $column) {
                             switch ($column) {
                                 case self::COLUMNS_CLI_VALUE_TEST_TAKER:
-                                    $this->columns = array_merge($this->columns, $this->getExporterService()->getTestTakerColumns());
+                                    $this->columns = array_merge(
+                                        $this->columns,
+                                        $this->getExporterService()->getTestTakerColumns()
+                                    );
                                     break;
 
                                 case self::COLUMNS_CLI_VALUE_DELIVERY:
-                                    $this->columns = array_merge($this->columns, $this->getExporterService()->getDeliveryColumns());
+                                    $this->columns = array_merge(
+                                        $this->columns,
+                                        $this->getExporterService()->getDeliveryColumns()
+                                    );
                                     break;
 
                                 case self::COLUMNS_CLI_VALUE_GRADES:
-                                    $this->columns = array_merge($this->columns, $this->getExporterService()->getGradeColumns());
+                                    $this->columns = array_merge(
+                                        $this->columns,
+                                        $this->getExporterService()->getGradeColumns()
+                                    );
                                     break;
 
                                 case self::COLUMNS_CLI_VALUE_RESPONSES:
-                                    $this->columns = array_merge($this->columns, $this->getExporterService()->getResponseColumns());
+                                    $this->columns = array_merge(
+                                        $this->columns,
+                                        $this->getExporterService()->getResponseColumns()
+                                    );
                                     break;
                             }
                         }
                         break;
 
                     case '--submittedVersion':
-                       if (!in_array($value, [
+                        if (!in_array(
+                            $value,
+                            [
                                 ResultsService::VARIABLES_FILTER_ALL,
                                 ResultsService::VARIABLES_FILTER_FIRST_SUBMITTED,
                                 ResultsService::VARIABLES_FILTER_LAST_SUBMITTED
-                            ])) {
-                            throw new \InvalidArgumentException('Invalid submitted version of variables "' . $value . '". Valid options: ' . implode(', ', [ResultsService::VARIABLES_FILTER_FIRST_SUBMITTED, ResultsService::VARIABLES_FILTER_LAST_SUBMITTED]));
+                            ]
+                        )) {
+                            throw new InvalidArgumentException(
+                                sprintf(
+                                    'Invalid submitted version of variables %s. Valid options: %s',
+                                    $value,
+                                    implode(', ', [
+                                        ResultsService::VARIABLES_FILTER_FIRST_SUBMITTED,
+                                        ResultsService::VARIABLES_FILTER_LAST_SUBMITTED
+                                    ])
+                                )
+                            );
                         }
 
                         $this->submittedVersion = $value;
@@ -235,11 +272,11 @@ class ExportDeliveryResults implements Action, ServiceLocatorAwareInterface, Wor
 
                     case '--dir':
                         if (!is_dir($value)) {
-                            throw new \InvalidArgumentException('Invalid directory "' . $value . '" provided.');
+                            throw new InvalidArgumentException('Invalid directory "' . $value . '" provided.');
                         }
 
                         if (!is_writable($value)) {
-                            throw new \InvalidArgumentException('Directory "' . $value . '" not writable.');
+                            throw new InvalidArgumentException('Directory "' . $value . '" not writable.');
                         }
                         $this->destination = $value;
                         break;
@@ -254,10 +291,7 @@ class ExportDeliveryResults implements Action, ServiceLocatorAwareInterface, Wor
         }
     }
 
-    /**
-     * @return array
-     */
-    private function getPossibleColumnValues()
+    private function getPossibleColumnValues(): array
     {
         return [
             self::COLUMNS_CLI_VALUE_ALL,

--- a/test/unit/model/export/SingleDeliverySqlResultExporterTest.php
+++ b/test/unit/model/export/SingleDeliverySqlResultExporterTest.php
@@ -71,19 +71,26 @@ class SingleDeliverySqlResultExporterTest extends TestCase
             ->method('getResource')
             ->willReturn($deliveryMock);
 
-        $singleDeliveryExporter = new SingleDeliverySqlResultExporterMock($modelMock, $deliveryMock, $resultServiceMock, $columnsProviderMock);
+        $singleDeliveryExporter = new SingleDeliverySqlResultExporterMock(
+            $modelMock,
+            $deliveryMock,
+            $resultServiceMock,
+            $columnsProviderMock
+        );
 
         $variableColumnsToExport = [
             new GradeColumn(
                 '',
                 'Tets Variable Grade Column',
                 '',
-                Variable::TYPE_VARIABLE_IDENTIFIER),
+                Variable::TYPE_VARIABLE_IDENTIFIER
+            ),
             new ResponseColumn(
                 '',
                 'Tets Variable Response Column',
                 '',
-                'nonexistent type')
+                'nonexistent type'
+            )
         ];
         $singleDeliveryExporter->setFixtureColumnsToExport($variableColumnsToExport);
 

--- a/test/unit/model/export/SingleDeliverySqlResultExporterTest.php
+++ b/test/unit/model/export/SingleDeliverySqlResultExporterTest.php
@@ -102,7 +102,6 @@ class SingleDeliverySqlResultExporterTest extends TestCase
 
         $this->assertEquals($sqlExpected, $sql);
     }
-
 }
 
 class SingleDeliverySqlResultExporterMock extends SingleDeliverySqlResultsExporter

--- a/test/unit/model/export/SingleDeliverySqlResultExporterTest.php
+++ b/test/unit/model/export/SingleDeliverySqlResultExporterTest.php
@@ -113,7 +113,7 @@ class SingleDeliverySqlResultExporterMock extends SingleDeliverySqlResultsExport
         return $this->getExporter($data);
     }
 
-    public function getColumnsToExport()
+    public function getColumnsToExport(): array
     {
         return $this->columns;
     }


### PR DESCRIPTION
This changes (first commit) fixing issue of failing CSV Result export UI due to a request running out of time.
Now we do not trigger `getColumnsToExport()` and do not instantiate `VariableColumn` classes and their data providers in scope of request which were produce significant load before.

How to test:
It is not possible to estimate impact through UI. But possible to check if no regression occurs.
- Make some deliveries passed by a test taker.
- Go to Results
- Check result table preview and export works fine with different options
- Check CSV results export for delivery or a class works fine