### PR TITLE
[BACKPORT] [NSA-353] cli exports are missing critical fields

### DIFF
--- a/model/export/SingleDeliveryResultsExporter.php
+++ b/model/export/SingleDeliveryResultsExporter.php
@@ -158,7 +158,8 @@ class SingleDeliveryResultsExporter implements ResultsExporterInterface
                 $columns = array_merge(
                     $this->columnsProvider->getTestTakerColumns(),
                     $this->columnsProvider->getDeliveryColumns(),
-                    $variables
+                    $variables,
+                    $this->columnsProvider->getDeliveryExecutionColumns()
                 );
             }
 

--- a/model/export/SingleDeliveryResultsExporter.php
+++ b/model/export/SingleDeliveryResultsExporter.php
@@ -251,8 +251,8 @@ class SingleDeliveryResultsExporter implements ResultsExporterInterface
     private function sortByStartDate(&$data)
     {
         usort($data, function ($a, $b) {
-            $bDate = $b[ColumnsProvider::LABEL_START_DELIVERY_EXECUTION];
-            $aDate = $a[ColumnsProvider::LABEL_START_DELIVERY_EXECUTION];
+            $bDate = $b[ColumnsProvider::LABEL_START_DELIVERY_EXECUTION] ?? null;
+            $aDate = $a[ColumnsProvider::LABEL_START_DELIVERY_EXECUTION] ?? null;
             $startB = $bDate ? strtotime($bDate) : 0;
             $startA = $aDate ? strtotime($aDate) : 0;
             return $startB - $startA;

--- a/test/unit/model/Builder/ResultsServiceBuilderTest.php
+++ b/test/unit/model/Builder/ResultsServiceBuilderTest.php
@@ -20,16 +20,19 @@
 
 namespace oat\taoOutcomeUi\unit\model\Builder;
 
-use oat\generis\test\TestCase;
+use oat\generis\test\ServiceManagerMockTrait;
 use oat\taoOutcomeUi\model\Builder\ResultsServiceBuilder;
 use oat\taoOutcomeUi\model\ResultsService;
 use oat\taoOutcomeUi\model\Wrapper\ResultServiceWrapper;
 use oat\taoResultServer\models\classes\ResultManagement;
 use oat\taoResultServer\models\classes\ResultServerService;
 use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
 
-class ResultsServiceTest extends TestCase
+class ResultsServiceBuilderTest extends TestCase
 {
+    use ServiceManagerMockTrait;
+
     /** @var ResultsService */
     private $subject;
 
@@ -46,7 +49,7 @@ class ResultsServiceTest extends TestCase
 
         $this->subject = new ResultsServiceBuilder();
         $this->subject->setServiceLocator(
-            $this->getServiceLocatorMock(
+            $this->getServiceManagerMock(
                 [
                     ResultServiceWrapper::SERVICE_ID => $this->resultServiceWrapper,
                     ResultServerService::SERVICE_ID => $this->resultServerService,

--- a/test/unit/model/search/ResultWatcherTest.php
+++ b/test/unit/model/search/ResultWatcherTest.php
@@ -21,7 +21,7 @@
 namespace oat\taoOutcomeUi\unit\model\search;
 
 use core_kernel_classes_Resource;
-use oat\generis\test\TestCase;
+use oat\generis\test\ServiceManagerMockTrait;
 use oat\oatbox\log\LoggerService;
 use oat\oatbox\user\User;
 use oat\oatbox\user\UserService;
@@ -33,9 +33,12 @@ use oat\taoDelivery\models\classes\execution\event\DeliveryExecutionCreated;
 use oat\taoOutcomeUi\model\search\ResultCustomFieldsService;
 use oat\taoOutcomeUi\model\search\ResultsWatcher;
 use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
 
 class ResultWatcherTest extends TestCase
 {
+    use ServiceManagerMockTrait;
+
     /**
      * @var ResultsWatcher
      */
@@ -70,7 +73,7 @@ class ResultWatcherTest extends TestCase
         $customFieldMock->method('getCustomFields')->willReturn([]);
 
         $this->subject->setServiceLocator(
-            $this->getServiceLocatorMock(
+            $this->getServiceManagerMock(
                 [
                     AdvancedSearchChecker::class => $this->advancedSearchChecker,
                     SearchProxy::SERVICE_ID => $this->searchService,


### PR DESCRIPTION
Ticket: https://oat-sa.atlassian.net/browse/NSA-353

## What's Changed

The reason which caused this issue is the ticket RE-255 which was supposed to fix an issue on the export UI. The side effect was that the fields were also removed from CLI. Now both bugs should be fixed with these changes

Refs: https://oat-sa.atlassian.net/browse/RE-255
Refs: https://oat-sa.atlassian.net/browse/NSA-353

## How to test
- please check: https://oat-sa.atlassian.net/browse/RE-255
- please check: https://oat-sa.atlassian.net/browse/NSA-353