### PR TITLE
fix: Correct result column value should present in an export

### DIFF
--- a/model/table/ColumnDataProvider/ColumnIdProvider.php
+++ b/model/table/ColumnDataProvider/ColumnIdProvider.php
@@ -25,6 +25,7 @@ namespace oat\taoOutcomeUi\model\table\ColumnDataProvider;
 use oat\taoOutcomeUi\model\ItemResultStrategy;
 use oat\taoOutcomeUi\model\table\ContextTypePropertyColumn;
 use oat\taoOutcomeUi\model\table\DeliveryExecutionColumn;
+use oat\taoOutcomeUi\model\table\ResponseColumn;
 use oat\taoOutcomeUi\model\table\TestCenterColumn;
 use oat\taoOutcomeUi\model\table\TraceVariableColumn;
 use oat\taoOutcomeUi\model\table\VariableColumn;
@@ -42,6 +43,8 @@ class ColumnIdProvider
     public function provide(tao_models_classes_table_Column $column): string
     {
         switch (true) {
+            case $column instanceof ResponseColumn:
+                return $column->getContextIdentifier() . '_' . $column->getIdentifier();
             case $column instanceof ContextTypePropertyColumn:
                 return $column->getProperty()->getUri() . '_' . $column->getContextType();
             case $column instanceof TestCenterColumn:

--- a/test/unit/model/ResultsServiceTest.php
+++ b/test/unit/model/ResultsServiceTest.php
@@ -506,6 +506,7 @@ class ResultsServiceTest extends TestCase
             $delivery,
             $variableClass
         );
+
         self::assertCount($expectedCountForInstanceStrategy, $columns);
         $expectedIndex = 0;
         foreach ($columns as $index => $column) {
@@ -611,14 +612,14 @@ class ResultsServiceTest extends TestCase
                 taoResultServer_models_classes_ResponseVariable::class,
                 ResponseColumn::class,
                 3,
-                2,
+                3,
                 [
                     [(object)[
                         'callIdItem' => sprintf('%s.%s.0', self::EXPECTED_DE_URI, 'item-1'),
                         'item' => self::EXPECTED_ITEM_URI,
                         'test' => self::EXPECTED_TEST_URI,
                         'deliveryResultIdentifier' => self::EXPECTED_DE_URI,
-                        'variable' => $this->getResponseVariable()
+                        'variable' => $this->getResponseVariable('response value', 'response')
                     ]],
                     [(object)[
                         'callIdItem' => sprintf('%s.%s.0', self::EXPECTED_DE_URI, 'item-2'),

--- a/test/unit/model/table/ColumnDataProvider/ColumnIdProviderTest.php
+++ b/test/unit/model/table/ColumnDataProvider/ColumnIdProviderTest.php
@@ -394,6 +394,21 @@ class ColumnIdProviderTest extends TestCase
         );
     }
 
+    public function testProvideFromColumnArrayForResponseColumn(): void
+    {
+        self::assertEquals(
+            'context_identifier_identifier',
+            $this->subject->provideFromColumnArray([
+                'contextId' => self::EXPECTED_CONTEXT_IDENTIFIER,
+                'contextLabel' => self::EXPECTED_LABEL,
+                'variableIdentifier' => self::EXPECTED_IDENTIFIER,
+                'columnType' => self::EXPECTED_COLUMN_TYPE,
+                'refId' => self::EXPECTED_REF_ID,
+                'type' => ResponseColumn::class
+            ])
+        );
+    }
+
     /**
      * @dataProvider provideColumnDataHash
      */
@@ -424,7 +439,6 @@ class ColumnIdProviderTest extends TestCase
     {
         return [
             [GradeColumn::class],
-            [ResponseColumn::class]
         ];
     }
 


### PR DESCRIPTION
Ticket - https://oat-sa.atlassian.net/browse/ADF-1503

How to test:
Correct result column must contain value during preview and csv export.
![Screenshot from 2023-06-04 20-27-41](https://github.com/oat-sa/extension-tao-outcomeui/assets/72205523/6e5bb854-1793-4e13-b06e-cd06e0c87881)

