### PR TITLE
refactor: use IndexDocumentBuilder::createDocument* methods directly

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -58,7 +58,7 @@
     "require": {
         "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
 		"oat-sa/generis" : ">=15.22",
-		"oat-sa/tao-core" : ">=50.24.6",
+		"oat-sa/tao-core" : ">=53.7.1",
 		"oat-sa/extension-tao-item" : ">=11.0.0",
 		"oat-sa/extension-tao-delivery-rdf" : ">=14.0.0",
 		"oat-sa/extension-tao-delivery" : ">=15.0.0",

--- a/model/search/ResultIndexIterator.php
+++ b/model/search/ResultIndexIterator.php
@@ -21,8 +21,8 @@
 namespace oat\taoOutcomeUi\model\search;
 
 use oat\tao\helpers\UserHelper;
+use oat\tao\model\search\index\DocumentBuilder\IndexDocumentBuilderInterface;
 use oat\tao\model\search\index\IndexDocument;
-use oat\tao\model\search\index\IndexService;
 use oat\taoDelivery\model\execution\DeliveryExecutionInterface;
 use oat\taoDelivery\model\execution\ServiceProxy;
 use oat\taoDelivery\model\execution\DeliveryExecution;
@@ -254,8 +254,12 @@ class ResultIndexIterator implements \Iterator
             'id' => $execution->getIdentifier(),
             'body' => $body
         ];
-        /** @var IndexService $indexService */
-        $indexService = $this->getServiceLocator()->get(IndexService::SERVICE_ID);
-        return $indexService->createDocumentFromArray($document);
+
+        return $this->getIndexDocumentBuilder()->createDocumentFromArray($document);
+    }
+
+    private function getIndexDocumentBuilder(): IndexDocumentBuilderInterface
+    {
+        return $this->getServiceLocator()->getContainer()->get(IndexDocumentBuilderInterface::class);
     }
 }


### PR DESCRIPTION
This PR aim is to sync refactoring changes with https://github.com/oat-sa/tao-core/pull/3888