### PR TITLE
fix: Remove new container usage in migration

### DIFF
--- a/migrations/Version202309041508164049_taoOutcomeUi.php
+++ b/migrations/Version202309041508164049_taoOutcomeUi.php
@@ -18,12 +18,12 @@ final class Version202309041508164049_taoOutcomeUi extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        if (!$this->getServiceManager()->getContainer()->has(ResultsViewerService::SERVICE_ID)) {
+        if (!$this->getServiceManager()->has(ResultsViewerService::SERVICE_ID)) {
             return;
         }
 
         /** @var ResultsViewerService $service */
-        $service = $this->getServiceManager()->getContainer()->get(ResultsViewerService::SERVICE_ID);
+        $service = $this->getServiceManager()->get(ResultsViewerService::SERVICE_ID);
         $defaultItemType = $service->getDefaultItemType();
 
         if (!$defaultItemType) {
@@ -31,7 +31,7 @@ final class Version202309041508164049_taoOutcomeUi extends AbstractMigration
         }
 
         /** @var DeliveryItemTypeService $service */
-        $service = $this->getServiceManager()->getContainer()->get(DeliveryItemTypeService::SERVICE_ID);
+        $service = $this->getServiceManager()->get(DeliveryItemTypeService::SERVICE_ID);
         $service->setDefaultItemType($defaultItemType);
         $this->getServiceManager()->register(DeliveryItemTypeService::SERVICE_ID, $service);
     }


### PR DESCRIPTION
Fallback to use legacy container in migration because new container usage cause the following issue during `taoUpdate` script launching:
```
Adding definition to a compiled container is not allowed.#0 /var/www/html/vendor/symfony/dependency-injection/ContainerBuilder.php(912): Symfony\Component\DependencyInjection\ContainerBuilder->setDefinition('service_contain...', Object(Symfony\Component\DependencyInjection\Definition))
#1 /var/www/html/vendor/symfony/dependency-injection/Compiler/MergeExtensionConfigurationPass.php(102): Symfony\Component\DependencyInjection\ContainerBuilder->addDefinitions(Array)
#2 /var/www/html/vendor/symfony/dependency-injection/Compiler/Compiler.php(91): Symfony\Component\DependencyInjection\Compiler\MergeExtensionConfigurationPass->process(Object(oat\generis\model\DependencyInjection\ContainerBuilder))
#3 /var/www/html/vendor/symfony/dependency-injection/ContainerBuilder.php(744): Symfony\Component\DependencyInjection\Compiler\Compiler->compile(Object(oat\generis\model\DependencyInjection\ContainerBuilder))
#4 /var/www/html/generis/core/DependencyInjection/ContainerCache.php(84): Symfony\Component\DependencyInjection\ContainerBuilder->compile()
#5 /var/www/html/generis/core/DependencyInjection/ContainerCache.php(79): oat\generis\model\DependencyInjection\ContainerCache->forceLoad()
#6 /var/www/html/generis/core/DependencyInjection/ContainerBuilder.php(97): oat\generis\model\DependencyInjection\ContainerCache->load()
#7 /var/www/html/tao/scripts/taoUpdate.php(38): oat\generis\model\DependencyInjection\ContainerBuilder->forceBuild()
#8 {main}
```