### PR TITLE
fix: change results order

### DIFF
--- a/views/js/component/results/list.js
+++ b/views/js/component/results/list.js
@@ -189,7 +189,9 @@ define([
                                 filter: self.config.searchable,
                                 labels: {
                                     filter: __('Search by delivery results')
-                                }
+                                },
+                                sortby: 'timestamp',
+                                sortorder: 'desc'
                             });
                     })
                     .catch(function (err) {


### PR DESCRIPTION
Ticket: https://oat-sa.atlassian.net/browse/RFE-1283
https://oat-sa.atlassian.net/browse/BSA-408

## What's Changed
- Changed results tab in order to show the table in the reversed chronological order

## How to test
- Check results are in reversed chronological order

**Deployed** on http://test-viktar.playground.kitchen.it.taocloud.org:41531/tao/Main