### PR TITLE
fix: correct action bar icon order weights (AUT-4491)

### DIFF
--- a/controller/structures.xml
+++ b/controller/structures.xml
@@ -21,10 +21,10 @@
                     <action id="results-csv-export" name="Export CSV" url="/taoOutcomeUi/Results/export" group="tree" context="resource" binding="export_csv" weight="8">
                         <icon id="icon-export"/>
                     </action>
-                    <action id="results-class-index" name="Results" url="/taoOutcomeUi/Results/index" group="content" context="class" weight="10">
+                    <action id="results-class-index" name="Results" url="/taoOutcomeUi/Results/index" group="content" context="class" weight="1">
                         <icon id="icon-result-small"/>
                     </action>
-                    <action id="results-index" name="Results" url="/taoOutcomeUi/Results/index" group="content" context="instance" weight="10">
+                    <action id="results-index" name="Results" url="/taoOutcomeUi/Results/index" group="content" context="instance" weight="1">
                         <icon id="icon-result-small"/>
                     </action>
                     <action id="results-export" name="Export Table" url="/taoOutcomeUi/ResultTable/index" group="tree" context="resource" weight="7">

--- a/controller/structures.xml
+++ b/controller/structures.xml
@@ -18,16 +18,16 @@
                     />
                 </trees>
                 <actions>
-                    <action id="results-csv-export" name="Export CSV" url="/taoOutcomeUi/Results/export" group="tree" context="resource" binding="export_csv">
+                    <action id="results-csv-export" name="Export CSV" url="/taoOutcomeUi/Results/export" group="tree" context="resource" binding="export_csv" weight="8">
                         <icon id="icon-export"/>
                     </action>
-                    <action id="results-class-index" name="Results" url="/taoOutcomeUi/Results/index" group="content" context="class">
+                    <action id="results-class-index" name="Results" url="/taoOutcomeUi/Results/index" group="content" context="class" weight="10">
                         <icon id="icon-result-small"/>
                     </action>
-                    <action id="results-index" name="Results" url="/taoOutcomeUi/Results/index" group="content" context="instance">
+                    <action id="results-index" name="Results" url="/taoOutcomeUi/Results/index" group="content" context="instance" weight="10">
                         <icon id="icon-result-small"/>
                     </action>
-                    <action id="results-export" name="Export Table" url="/taoOutcomeUi/ResultTable/index" group="tree" context="resource">
+                    <action id="results-export" name="Export Table" url="/taoOutcomeUi/ResultTable/index" group="tree" context="resource" weight="7">
                         <icon id="icon-table"/>
                     </action>
                 </actions>


### PR DESCRIPTION
# fix: correct action bar icon order weights (AUT-4491)

## Summary

- Adds missing `weight` attributes to all action definitions in `structures.xml` files across affected extensions.
- Fixes incorrect icon order in the Actions menu (all tabs) when the QuickWins design feature flag is enabled.
- Root cause: `getSortedActionsByWeight()` in `tao/helpers/Layout.php` sorts ascending by weight; weights were never consistently set when weight-based sorting was introduced in AUT-3938.

## Weight conventions applied

### Tree actions (lower = leftmost)
| Weight | Action type |
|--------|------------|
| 10 | New class |
| 9 | Delete (instance / class / all) |
| 8 | Import |
| 7 | Export / Publish |
| 6 | Duplicate |
| 5 | Copy To |
| 4 | Move To |
| 3 | Translate |
| 1 | New [entity] (primary create action) |

### Content actions
| Weight | Action type |
|--------|------------|
| 10 | Properties (instance / class) |
| 9 | Preview |
| 8 | Authoring |
| 7 | History |
| 6 | Usage |
| 5 | Item Statistics |
| 3 | Manage Schema |

## Impacted extensions

- `extension-tao-item` (taoItems)
- `extension-tao-itemqti` (taoQtiItem)
- `extension-tao-test` (taoTests)
- `extension-tao-testqti` (taoQtiTest)
- `extension-tao-group` (taoGroups)
- `extension-tao-testtaker` (taoTestTaker)
- `extension-tao-delivery-rdf` (taoDeliveryRdf)
- `extension-tao-deliver-connect` (taoDeliverConnect)
- `extension-tao-backoffice` (taoBackOffice)
- `extension-tao-outcomeui` (taoOutcomeUi)
- `extension-tao-proctoring` (taoProctoring)
- `extension-remote-proctoring` (remoteProctoring)
- `extension-tao-lti-consumer` (taoLtiConsumer)
- `extension-tao-testcenter` (taoTestCenter)
- `extension-tao-blueprints` (taoBlueprints)
- `extension-tao-mediamanager` (taoMediaManager)

## Testing

Enable the QuickWins design feature flag and verify the Actions toolbar icons appear in the correct order on all tabs (Items, Tests, Test-Takers, Groups, Deliveries, Results, Assets, Blueprints, Test Centers).

No code logic changes — XML `weight` attribute additions/corrections only.

## Related

- Jira: AUT-4491
- Introduced by: AUT-3938 (weight-based sort added to Layout.php)