### PR TITLE
fix: correct results export order for AUT-4491

### DIFF
--- a/controller/structures.xml
+++ b/controller/structures.xml
@@ -18,7 +18,7 @@
                     />
                 </trees>
                 <actions>
-                    <action id="results-csv-export" name="Export CSV" url="/taoOutcomeUi/Results/export" group="tree" context="resource" binding="export_csv" weight="8">
+                    <action id="results-csv-export" name="Export CSV" url="/taoOutcomeUi/Results/export" group="tree" context="resource" binding="export_csv" weight="7">
                         <icon id="icon-export"/>
                     </action>
                     <action id="results-class-index" name="Results" url="/taoOutcomeUi/Results/index" group="content" context="class" weight="1">
@@ -27,7 +27,7 @@
                     <action id="results-index" name="Results" url="/taoOutcomeUi/Results/index" group="content" context="instance" weight="1">
                         <icon id="icon-result-small"/>
                     </action>
-                    <action id="results-export" name="Export Table" url="/taoOutcomeUi/ResultTable/index" group="tree" context="resource" weight="7">
+                    <action id="results-export" name="Export Table" url="/taoOutcomeUi/ResultTable/index" group="tree" context="resource" weight="8">
                         <icon id="icon-table"/>
                     </action>
                 </actions>


### PR DESCRIPTION
## Jira issue

https://oat-sa.atlassian.net/browse/AUT-4491

## Summary

- adjust Results tree action ordering in `taoOutcomeUi` for deterministic display

## What changed

- set `Export CSV` to weight `7`
- set `Export Table` to weight `8`
- keep `Export CSV` declared before `Export Table` in `controller/structures.xml`

## Validation

- verified `controller/structures.xml` action order and weights in `manage_results` section


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reordered export actions in the "Manage Results" section to improve UI organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->